### PR TITLE
One possible bug fix, other minor grammar suggestions.

### DIFF
--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -67,8 +67,8 @@ namespace curl  {
          */
         explicit curl_easy(const long);
         /**
-         * This overloaded constructor allows to specify the environment
-         * initialization flags and a stream where to put libcurl output.
+         * This overloaded constructor specifies the environment
+         * initialization flags and an output stream for the libcurl output.
          */
         curl_easy(const long, curl_writer &);
         /**
@@ -77,17 +77,17 @@ namespace curl  {
          */
         curl_easy(const curl_easy &);
         /**
-         * Assignment operator used to perform assignment between object
+         * Assignment operator used to perform assignment between objects
          * of this class.
          */
         curl_easy &operator=(const curl_easy &);
         /**
          * Override of equality operator. It has been overridden to check
-         * whether two curl_easy object are equal.
+         * whether two curl_easy objects are equal.
          */
         bool operator==(const curl_easy &) const;
         /**
-         * The destructor will perform cleaning operations.
+         * The destructor will perform cleanup operations.
          */
         ~curl_easy() noexcept;
         /**
@@ -103,41 +103,39 @@ namespace curl  {
         template<typename Iterator> void add(Iterator, const Iterator);
         /**
          * This method allows users to request internal information from
-         * the curl session. I recommend to read online documentation for
+         * the curl session. I recommend reading online documentation for
          * further information.
          */
         template<typename T> unique_ptr<T> get_info(const CURLINFO) const;
         /**
          * get_info overloaded method. It it used when the second argument is
-         * of struct_slist * type.
+         * of type struct_slist*.
          */
         unique_ptr<vector<string>> get_info(const CURLINFO) const;
         /**
-         * Using this function, you can explicitly mark a running connection 
-         * to get paused, and you can resume a connection that was previously
-         * paused.
+         * Using this function, you can explicitly pause a running connection, 
+         * and you can resume a previously paused connection.
          */
         void pause(const int);
         /**
          * This function converts the given input string to an URL encoded
-         * string and returns that as a new allocated string.
+         * string and returns a newly allocated string.
          */
         void escape(string &);
         /**
          * This function converts the given URL encoded input string to a
-         * "plain string" and returns that in an allocated memory area. 
+         * "plain string" and returns a newly allocated string.
          */
         void unescape(string &);
         /**
-         * This function performs all the operations that user has specified
+         * This function performs all the operations a user has specified
          * with the add methods. If the performing operation has finished
-         * the method returns true. Else, returns false.
+         * the method returns true otherwise false.
          */
         void perform();
         /**
          * Re-initializes all options previously set on a specified CURL handle
-         * to the default values. This puts back the handle to the same state as
-         * it was in when it was just created with.
+         * to the default values. This puts the handle back to the initial state.
          */
         void reset() noexcept;
         /**
@@ -165,7 +163,6 @@ namespace curl  {
 
     // Implementation of get_session_info method.
     template<typename T> unique_ptr<T> curl_easy::get_info(const CURLINFO info) const {
-        // Uses a unique_ptr to automatically destroy the memory reserved with new when the pointer goes out of scope.
         unique_ptr<T> ptr(new T);
         const CURLcode code = curl_easy_getinfo(this->curl,info,ptr.get());
         if (code != CURLE_OK) {

--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -62,7 +62,7 @@ namespace curl {
         ~curl_exception() noexcept;
         using exception::what;
         /**
-         * Override of exception's what method, used to returns
+         * Override of exception's what method, used to return
          * the vector of errors.
          */
         const vector<pair<string,string>> what();
@@ -73,7 +73,7 @@ namespace curl {
     private:
         /**
          * The error container must be static or will be cleared
-         * when an exceptions is thrown.
+         * when an exception is thrown.
          */
         static vector<pair<string,string>> traceback;
     };
@@ -91,7 +91,7 @@ namespace curl {
     }
     
     /**
-     * Derived class used to represents a condition of error returned by the easy
+     * Derived class represents an error condition returned by the easy
      * interface functions.
      */
     class curl_easy_exception : public curl_exception {
@@ -108,30 +108,30 @@ namespace curl {
     };
     
     /**
-     * Derived class used to represents a condition of error returned by the multi
+     * Derived class represents an error condition returned by the multi
      * interface functions.
      */
     class curl_multi_exception : public curl_exception {
     public:
         /**
-         * This constructor allows to specify a custom error message and the method name where
+         * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
         curl_multi_exception(const string error, const string method) : curl_exception(error,method) {}
         /**
-         * The constructor will transform a CURLMcode error in a proper error message.
+         * The constructor will transform a CURLMcode error to a proper error message.
          */
         curl_multi_exception(const CURLMcode code, const string method) : curl_exception(curl_multi_strerror(code),method) {}
     };
     
     /**
-     * Derived class used to represents a condition of error returned by the share
+     * Derived class used to represent an error condition returned by the share
      * interface functions.
      */
     class curl_share_exception : public curl_exception {
     public:
         /**
-         * This constructor allows to specify a custom error message and the method name where
+         * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
         curl_share_exception(const string error, const string method) : curl_exception(error,method) {}

--- a/include/curl_form.h
+++ b/include/curl_form.h
@@ -41,7 +41,7 @@ namespace curl {
     /**
      * This class simplifies the creation of a form. It wraps all the libcurl
      * functions used to add content to a form and to destroy it.
-     */   
+     */
     class curl_form {
     public:
         /**
@@ -56,28 +56,28 @@ namespace curl {
         ~curl_form() noexcept;
         /**
          * Copy constructor used to perform a deep copy of the form content
-         * list. Without it we would be not able to perform copy. 
+         * list. Without it we would not be able to perform the copy.
          */
         curl_form(const curl_form &);
         /**
-         * Assignment operator to implement assignment between two object
+         * Assignment operator to implement assignment between two objects
          * of this class.
          */
         curl_form &operator=(const curl_form &);
         /**
-         * This method allows users to add content to a form, using the 
+         * This method allows users to add content to a form, using the
          * curl_pair class.
          */
         void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &);
         /**
          * Overloaded add method.
          */
-        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &); 
+        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &);
         /**
          * Overloaded add method. It adds another curl_pair object to add more
          * contents to the form contents list.
          */
-        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,int> &); 
+        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,int> &);
         /**
          * Overloaded add method. It adds another curl_pair object to add more
          * contents to the form contents list.
@@ -87,9 +87,9 @@ namespace curl {
          * Overloaded add method. It adds another curl_pair object to add more
          * contents to the form contents list.
          */
-        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,int> &, const curl_pair<CURLformoption,string> &); 
+        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,int> &, const curl_pair<CURLformoption,string> &);
         /**
-         * Overloaded add method. This version is primarily used to upload multiple files. 
+         * Overloaded add method. This version is primarily used to upload multiple files.
          * You can pass a vector of filenames to upload them.
          */
         void add(const curl_pair<CURLformoption,string> &, const vector<string> &);
@@ -99,14 +99,14 @@ namespace curl {
         const struct curl_httppost *get() const;
     protected:
         /**
-         * This utility function is used to check if a given pointer, is null.
+         * This utility function is used to check if a given pointer is null.
          */
         template<typename T> void is_null(const T *ptr) const;
         /**
-         * This utility function is used to perform a deep copy of 
+         * This utility function is used to perform a deep copy of
          * the form contents list. We must traverse the new list to
          * copy all the field in the left-object's list. This method
-         * puts the node in the tail. Indeed, libcurl keeps two 
+         * puts the node in the tail. Indeed, libcurl keeps two
          * pointers to implement this list: a tail and a head.
          */
         void copy_ptr(struct curl_httppost **, const struct curl_httppost *);
@@ -119,14 +119,14 @@ namespace curl {
     inline curl_form::curl_form(const curl_form &form) : form_post(nullptr), last_ptr(nullptr) {
         *this = form;
     }
-    
+
     // Implementation of utility function to check if a pointer points to null.
     template<typename T> inline void curl_form::is_null(const T *ptr) const {
         if (ptr == nullptr) {
             throw bad_alloc();
         }
     }
-    
+
     // Implementation of getter method that returns the list head.
     inline const struct curl_httppost *curl_form::get() const {
         return this->form_post;

--- a/include/curl_header.h
+++ b/include/curl_header.h
@@ -35,7 +35,7 @@ using std::initializer_list;
 
 namespace curl {
     /**
-     * This class represents a generic header. It allows user to add
+     * This class represents a generic header. It allows a user to add
      * headers without caring about deallocation of resources.
      */
     class curl_header {
@@ -92,7 +92,7 @@ namespace curl {
     inline curl_header::curl_header(const curl_header &header) : headers(nullptr) {
         *this = header;
     }
-    
+
     // Implementation of overloaded add method.
     template<typename Iterator> void curl_header::add(Iterator begin, const Iterator end) {
         for (; begin != end; ++begin) {

--- a/include/curl_info.h
+++ b/include/curl_info.h
@@ -46,8 +46,8 @@ namespace curl {
          */
         curl_info();
         /**
-         * Overloaded constructor that allows users to specify a specific
-         * version of libcurl.
+         * Overloaded constructor that allows users to specify the 
+         * libcurl version.
          */
         explicit curl_info(const CURLversion);
         /**

--- a/include/curl_interface.h
+++ b/include/curl_interface.h
@@ -33,19 +33,19 @@ using curl::curl_exception;
 
 namespace curl {
     /**
-     * This is class is a common interface for all the libcurl interfaces:
+     * This class is a common interface for all the libcurl interfaces:
      * easy, multi and share. It provides methods that these three interfaces
-     * has in common with each other.
+     * have in common with each other.
      */
     template<class T> class curl_interface {
     protected:
         /**
-         * The default constructor will initializes the curl
+         * The default constructor will initialize the curl
          * environment with the default flag.
          */
         curl_interface();
         /**
-         * Overloaded constuctor that initializes curl environment
+         * Overloaded constructor that initializes curl environment
          * with user specified flag.
          */
         explicit curl_interface(const long);
@@ -67,7 +67,7 @@ namespace curl {
     
     // Implementation of overloaded constructor.
     template<class T> curl_interface<T>::curl_interface(const long flag) {
-        const CURLcode code = curl_global_init(CURL_GLOBAL_ALL);
+        const CURLcode code = curl_global_init(flag);
         if (code != CURLE_OK) {
             throw curl_easy_exception(code,__FUNCTION__);
         }

--- a/include/curl_multi.h
+++ b/include/curl_multi.h
@@ -47,8 +47,8 @@ namespace curl {
         /**
          * The multi interface gives users the opportunity to get information about
          * transfers. This information is wrapped in the following class. In this
-         * way users can access to these information in an easy and efficiently way.
-         * This class is nested because these messages have sense just when using the
+         * way users can access this information in an easy and efficient way.
+         * This class is nested because these messages are only sent when using the
          * multi interface.
          */
         class curl_message {
@@ -82,13 +82,13 @@ namespace curl {
          * Simple default constructor. It is used to give a
          * default value to all the attributes and provide a
          * fast way to create an object of this type. It also
-         * initialize the curl environment with the default
+         * initializes the curl environment with the default
          * values.
          */
         curl_multi();
         /**
          * Overloaded constructor. Gives users the opportunity
-         * to initialize the entire curl environment using customs
+         * to initialize the entire curl environment using custom
          * options.
          */
         explicit curl_multi(const long);
@@ -125,7 +125,7 @@ namespace curl {
          */
         void add(const curl_easy &);
         /**
-         * This method allows to remove an easy handler from the multi handler.
+         * This method removes an easy handler from the multi handler.
          */
         void remove(const curl_easy &);
         /**
@@ -144,7 +144,7 @@ namespace curl {
         bool is_finished(const curl_easy &);
         /**
          * Perform all the operations. Go baby! If the performing operations
-         * has finished, the method returns true. Else, returns false. Check
+         * have finished, the method returns true. Else, returns false. Check
          * online documentation for further documentation.
          */
         bool perform();
@@ -171,7 +171,7 @@ namespace curl {
          */
         void assign(const curl_socket_t, void *); 
         /**
-         * If you are using the libcurl multi interface your should call this method
+         * If you are using the libcurl multi interface you should call this method
          * to figure out how long your application should wait for socket actions
          * - at most - before proceeding.
          */

--- a/include/curl_pair.h
+++ b/include/curl_pair.h
@@ -43,7 +43,7 @@ namespace curl {
     /**
      * This is a class that wraps two objects: an option and the value for
      * that option. It's very useful when building forms or setting options
-     * for easy/multi/share handlers. It let you specify the libcurl option
+     * for easy/multi/share handlers. It lets you specify the libcurl option
      * and its value.
      */
     template<class T, class K> class curl_pair {
@@ -72,7 +72,7 @@ namespace curl {
         
     /**
      * Template specialization for C++ strings. Why do we need this? Because
-     * curl_pair must be passed to C functions that doesen't know how to
+     * curl_pair must be passed to C functions that don't know how to
      * handle C++ string type, so we can specialize curl_pair class in a
      * manner that its methods returns a const char *.
      */
@@ -141,7 +141,7 @@ namespace curl {
     template<class T> class curl_pair<T,curl_header> {
     public:
         /**
-         * Thw two parameters constructor gives users a fast way to build an object
+         * The two parameters constructor gives users a fast way to build an object
          * of this type.
          */
         curl_pair(const T option, const curl_header &value) : option(option), value(value) {}

--- a/include/curl_receiver.h
+++ b/include/curl_receiver.h
@@ -34,13 +34,13 @@ using curl::curl_easy;
 
 namespace curl {
     /**
-     * This class implement a receiver that allows users to receives raw
+     * This class implements a receiver that allow users to receive raw
      * data on an established connection on an easy handler.
      */
     template<class T, const size_t SIZE> class curl_receiver {
     public:
         /**
-         * The default constructor simply initialize the attributes. In this
+         * The default constructor simply initializes the attributes. In this
          * case just the received bytes number is initialized to zero.
          */
         curl_receiver();

--- a/include/curl_writer.h
+++ b/include/curl_writer.h
@@ -54,8 +54,8 @@ namespace curl {
         curl_writer(ostream &);
         /**
          * This overloaded constructor allows users to specify a writer
-         * callback function used specify how to write something on the
-         * the default stream which is std::cout;
+         * callback function used to specify how to write something on
+         * the default stream (which is std::cout;)
          */
         curl_writer(curlcpp_writer_type);
         /**


### PR DESCRIPTION
In curl_interface.h, at overloaded constructor with const long flag argument, modified curl_global_init by adding flag in place of CURL_GLOBAL_ALL. Other changes are suggested English grammar modifications.
