### PR TITLE
Generate configuration file for external project

### DIFF
--- a/CMake/curlcppConfig.cmake.in
+++ b/CMake/curlcppConfig.cmake.in
@@ -1,0 +1,5 @@
+# curlcppConfig.cmake - Configuration file for external projects.
+
+set(CURLCPP_INCLUDE_DIRS "@CURLCPP_SOURCE_DIR@/include")
+set(CURLCPP_LIBRARY_DIRS "@CURLCPP_BINARY_DIR@/src")
+set(CURLCPP_LIBRARIES "@CURLCPP_LIB_LOCATION@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
-SET(CURL_MIN_VERSION "7.28.0")
+cmake_minimum_required(VERSION 2.8)
+set(CURL_MIN_VERSION "7.28.0")
 
 # Setting up project
-PROJECT(CURLCPP)
+project(CURLCPP)
 
 
 # Add MacPorts
@@ -11,13 +11,13 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 # Checking for dependencies
-FIND_PACKAGE(CURL ${CURL_MIN_VERSION} REQUIRED)
+find_package(CURL ${CURL_MIN_VERSION} REQUIRED)
 
 # Set up include pathes
-INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
-INCLUDE_DIRECTORIES(${CURLCPP_SOURCE_DIR}/include)
+include_directories(${CURL_INCLUDE_DIRS}
+  ${CURLCPP_SOURCE_DIR}/include)
 
 # Set up source directories
-ADD_SUBDIRECTORY(src)
+add_subdirectory(src)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,4 +20,7 @@ include_directories(${CURL_INCLUDE_DIRS}
 # Set up source directories
 add_subdirectory(src)
 
+get_property(CURLCPP_LIB_LOCATION TARGET curlcpp PROPERTY LOCATION)
 
+configure_file(CMake/curlcppConfig.cmake.in
+  ${CURLCPP_BINARY_DIR}/curlcppConfig.cmake @ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,18 @@
-SET(CURLCPP_SOURCE
+set(CURLCPP_SOURCE
   curl_easy.cpp
   curl_header.cpp
   curl_form.cpp
   curl_multi.cpp
   curl_share.cpp
   curl_info.cpp
-  curl_exception.cpp	
+  curl_exception.cpp
   curl_writer.cpp
 )
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 
-
-ADD_LIBRARY(curlcpp STATIC ${CURLCPP_SOURCE})
-TARGET_LINK_LIBRARIES(curlcpp ${CURL_LIBRARY})
+add_library(curlcpp STATIC ${CURLCPP_SOURCE})
+target_link_libraries(curlcpp ${CURL_LIBRARY})


### PR DESCRIPTION
In your external project, simply call

```
find_package(curlcpp PATHS /path/to/curlcpp/build/directory)
```

to set the variables

```
CURLCPP_INCLUDE_DIRS
CURLCPP_LIBRARY_DIRS
CURLCPP_LIBRARIES
```

with all the valid paths generated during the curlcpp build. For more information, check the ```find_package()``` documentation [1].

I also took the opportunity to change the CMake syntax to lower case.

  [1]: http://www.cmake.org/cmake/help/v3.1/command/find_package.html