### PR TITLE
Version notice in readme, especially useful for Mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ An object-oriented C++ wrapper for cURL tool
 
 If you want to know a bit more about cURL, you should go on the official website and read about the three interfaces that curl implements: http://curl.haxx.se/
 
+Please note: this requires C++11. For Mac users, you will probably need to update your compiler, since xCode provides a dated version.
+
 Compile and link
 ================
 


### PR DESCRIPTION
I struggled with weird errors for a while before I realized that the c++ version that comes with xCode is out of date. Upgrading to gcc4.9 and setting `export CXX=/usr/local/bin/gcc-4.9` did the trick.

Feel free to reword or put in a better spot. I think it's a useful thing to have, though. Perhaps as part of the installation instructions, if not where I put it.