### PR TITLE
Fix for bug #32 and #33 and some clean up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,13 @@ IF(BIICODE)
     ADD_BIICODE_TARGETS()
 ELSE()
     cmake_minimum_required(VERSION 2.8)
-    set(CURL_MIN_VERSION "7.28.0")
-
+    #if using an older VERSION of curl ocsp stapling can be disabled
+    if(WITHOUT_OCSP_STAPLING)
+        set(CURL_MIN_VERSION "7.28.0")
+        add_definitions(-DWITHOUT_OCSP_STAPLING)
+    else()
+        set(CURL_MIN_VERSION "7.41.0")
+    endif()
     # Setting up project
     project(CURLCPP)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ cmake ..
 make # -j2
 ```
 
+**Note:** cURL 7.28 is required, but if you are using cURL < 7.41 you have to replace the cmake command with this one:
+
+```bash
+cmake .. -WITHOUT_OCSP_STAPLING=1
+```
+
 Then add `<curlcpp root>/build/src/` to your library path and `<curlcpp root>/include/` to your include path.
 
 When linking, link against `curlcpp` (e.g.: g++ -std=c++11 example.cpp -o example -lcurlcpp -lcurl).

--- a/include/curl_config.h
+++ b/include/curl_config.h
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 - Qiangqiang Wu
+ * Copyright (c) 2015 - Qiangqiang Wu, Ferdinand Thiessen
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,10 +25,11 @@
 #ifndef QQIANGWU_CURL_CONFIG_H_
 #define QQIANGWU_CURL_CONFIG_H_
 
-#ifndef _MSC_VER
-#define NOEXCEPT noexcept
+#if defined(_MSC_VER)
+    #define NOEXCEPT
+    #include <ciso646>
 #else
-#define NOEXCEPT
+    #define NOEXCEPT noexcept
 #endif
 
 #endif //!QQIANGWU_CURL_CONFIG_H_

--- a/include/curl_config.h
+++ b/include/curl_config.h
@@ -22,8 +22,8 @@
  * SOFTWARE.
  */
  
-#ifndef QQIANGWU_CURL_CONFIG_H_
-#define QQIANGWU_CURL_CONFIG_H_
+#ifndef __curlcpp__curl_config__
+#define __curlcpp__curl_config__
 
 #if defined(_MSC_VER)
     #define NOEXCEPT
@@ -32,4 +32,4 @@
     #define NOEXCEPT noexcept
 #endif
 
-#endif //!QQIANGWU_CURL_CONFIG_H_
+#endif /* defined(__curlcpp__curl_config__) */

--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -23,8 +23,8 @@
  * SOFTWARE.
  */
 
-#ifndef curl_easy_H
-#define	curl_easy_H
+#ifndef __curlcpp__curl_easy__
+#define __curlcpp__curl_easy__
 
 #include <algorithm>
 #include <curl/curl.h>
@@ -994,4 +994,4 @@ namespace curl  {
 }
 
 #undef CURLCPP_DEFINE_OPTION
-#endif	/* curl_easy_H */
+#endif	/* defined(__curlcpp__curl_easy__) */

--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -839,9 +839,10 @@ namespace curl  {
 
         /* Path to Unix domain socket */
         CURLCPP_DEFINE_OPTION(CURLOPT_UNIX_SOCKET_PATH, const char*);
-
+#if !defined(WITHOUT_OCSP_STAPLING)
         /* Set if we should verify the certificate status. */
         CURLCPP_DEFINE_OPTION(CURLOPT_SSL_VERIFYSTATUS, long);
+#endif
     }  // of namespace detail
 
     /**

--- a/include/curl_header.h
+++ b/include/curl_header.h
@@ -23,8 +23,8 @@
  * SOFTWARE.
  */
 
-#ifndef curl_header_H
-#define	curl_header_H
+#ifndef __curlcpp__curl_header__
+#define __curlcpp__curl_header__
 
 #include <string>
 #include <initializer_list>
@@ -103,4 +103,4 @@ namespace curl {
     }
 }
 
-#endif	/* curl_header_H */
+#endif	/* defined(__curlcpp__curl_header__) */

--- a/include/curl_info.h
+++ b/include/curl_info.h
@@ -23,8 +23,8 @@
  * SOFTWARE.
  */
 
-#ifndef __curlcpp__curl_version__
-#define __curlcpp__curl_version__
+#ifndef __curlcpp__curl_info__
+#define __curlcpp__curl_info__
 
 #include <curl/curl.h>
 #include <string>
@@ -165,4 +165,4 @@ namespace curl {
     }
 }
 
-#endif /* defined(__curlcpp__curl_version__) */
+#endif /* defined(__curlcpp__curl_info__) */

--- a/include/curl_interface.h
+++ b/include/curl_interface.h
@@ -23,8 +23,8 @@
  * SOFTWARE.
  */
 
-#ifndef curl_interface_H
-#define	curl_interface_H
+#ifndef __curlcpp__curl_interface__
+#define __curlcpp__curl_interface__
 
 #include <curl/curl.h>
 #include "curl_exception.h"
@@ -79,4 +79,4 @@ namespace curl {
     }
 }
 
-#endif	/* curl_interface_H */
+#endif	/* defined(__curlcpp__curl_interface__) */

--- a/include/curl_multi.h
+++ b/include/curl_multi.h
@@ -23,8 +23,8 @@
  * SOFTWARE.
  */
 
-#ifndef curl_multi_H
-#define	curl_multi_H
+#ifndef __curlcpp__curl_multi__
+#define __curlcpp__curl_multi__
 
 #include "curl_easy.h"
 
@@ -231,4 +231,4 @@ namespace curl {
     }
 }
 
-#endif	/* curl_multi_H */
+#endif	/* defined(__curlcpp__curl_multi__) */

--- a/include/curl_pair.h
+++ b/include/curl_pair.h
@@ -23,8 +23,8 @@
  * SOFTWARE.
  */
 
-#ifndef curl_pair_H
-#define	curl_pair_H
+#ifndef __curlcpp__curl_pair__
+#define __curlcpp__curl_pair__
 
 #include <string>
 #include "curl_config.h"
@@ -193,4 +193,4 @@ namespace curl {
     };
 }
 
-#endif	/* curl_pair_H */
+#endif	/* defined(__curlcpp__curl_pair__) */

--- a/include/curl_utility.h
+++ b/include/curl_utility.h
@@ -5,8 +5,8 @@
  * Created on March 26, 2014, 21:17 PM
  */
 
-#ifndef curl_utility_H
-#define curl_utility_H
+#ifndef __curlcpp__curl_utility__
+#define __curlcpp__curl_utility__
 
 #include <string>
 #include "curl_exception.h"
@@ -47,4 +47,4 @@ namespace curl {
     }
 }
 
-#endif /* curl_interface_H */
+#endif /* defined(__curlcpp__curl_utility__) */


### PR DESCRIPTION
As the title says this pull-request contains fixes for bug #32 (Compatibility with curl < 7.41) and bug #33 (Compatibility with MS VC++ compiler).
I also cleaned up the include guards (most of them had the same style, but some not. So I unified them).