### PR TITLE
Cleaner code to detect curl version (backwards compatibility)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,7 @@ IF(BIICODE)
 ELSE()
     cmake_minimum_required(VERSION 2.8)
     #if using an older VERSION of curl ocsp stapling can be disabled
-    if(WITHOUT_OCSP_STAPLING)
-        set(CURL_MIN_VERSION "7.28.0")
-        add_definitions(-DWITHOUT_OCSP_STAPLING)
-    else()
-        set(CURL_MIN_VERSION "7.41.0")
-    endif()
+    set(CURL_MIN_VERSION "7.28.0")
     # Setting up project
     project(CURLCPP)
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ cmake ..
 make # -j2
 ```
 
-**Note:** cURL 7.28 is required, but if you are using cURL < 7.41 you have to replace the cmake command with this one:
-
-```bash
-cmake .. -WITHOUT_OCSP_STAPLING=1
-```
+**Note:** cURL >= 7.28 is required.
 
 Then add `<curlcpp root>/build/src/` to your library path and `<curlcpp root>/include/` to your include path.
 

--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -839,7 +839,9 @@ namespace curl  {
 
         /* Path to Unix domain socket */
         CURLCPP_DEFINE_OPTION(CURLOPT_UNIX_SOCKET_PATH, const char*);
-#if !defined(WITHOUT_OCSP_STAPLING)
+
+		//OCSP STAPLING requires curl 7.41 or later, so check if available
+#if defined(LIBCURL_VERSION_NUM) && LIBCURL_VERSION_NUM >= 0x072900
         /* Set if we should verify the certificate status. */
         CURLCPP_DEFINE_OPTION(CURLOPT_SSL_VERIFYSTATUS, long);
 #endif


### PR DESCRIPTION
I think this way is much better then my old version, so with this the user has not to set a compile flag only because he has an old version of curl.