### PR TITLE
Fix gcc warnings

### DIFF
--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -66,7 +66,7 @@ namespace curl {
         /**
          * Returns the vector of errors.
          */
-        const vector<pair<string,string>> get_traceback();
+        vector<pair<string,string>> get_traceback() const;
         /**
          * Simple method which prints the entire error stack.
          */
@@ -87,7 +87,7 @@ namespace curl {
     }
     
     // Implementation of get_traceback.
-    inline const vector<pair<string,string>> curl_exception::get_traceback() {
+    inline vector<pair<string,string>> curl_exception::get_traceback() const {
         return curl_exception::traceback;
     }
     

--- a/include/curl_info.h
+++ b/include/curl_info.h
@@ -56,111 +56,111 @@ namespace curl {
          * Returns a string that shows what host information that this
          * libcurl was built for.
          */
-        const string get_host() const NOEXCEPT;
+        string get_host() const NOEXCEPT;
         /**
          * Returns a string for the OpenSSL version used. If libcurl has no
          * SSL support, the method returns null.
          */
-        const string get_ssl_version() const NOEXCEPT;
+        string get_ssl_version() const NOEXCEPT;
         /**
          * Returns a string for libz compression library version. If libcurl
          * has no libz support, the method returns null.
          */
-        const string get_libz_version() const NOEXCEPT;
+        string get_libz_version() const NOEXCEPT;
         /**
          * No description supplied for this method.
          */
-        const string get_ares() const NOEXCEPT;
+        string get_ares() const NOEXCEPT;
         /**
          * No description supplied for this method.
          */
-        const string get_libidn() const NOEXCEPT;
+        string get_libidn() const NOEXCEPT;
         /**
          * Returns a string for libssh library version. If libcurl
          * has no libssh support, the method returns null.
          */
-        const string get_libssh_version() const NOEXCEPT;
+        string get_libssh_version() const NOEXCEPT;
         /**
          * Returns the version number.
          */
-        const unsigned int get_version_number() const NOEXCEPT;
+        unsigned int get_version_number() const NOEXCEPT;
         /**
          * Check online documentation for the possible return values.
          */
-        const int get_features() const NOEXCEPT;
+        int get_features() const NOEXCEPT;
         /**
          * No description supplied for this method.
          */
-        const int get_ares_number() const NOEXCEPT;
+        int get_ares_number() const NOEXCEPT;
         /**
          * No description supplied for this method.
          */
-        const int get_iconv_version_number() const NOEXCEPT;
+        int get_iconv_version_number() const NOEXCEPT;
         /**
          * Returns the libssl version number.
          */
-        const long get_ssl_version_number() const NOEXCEPT;
+        long get_ssl_version_number() const NOEXCEPT;
         /**
          * Returns a list of all the protocols supported in the
          * running version of libcurl library.
          */
-        const list<string> get_protocols() const NOEXCEPT;
+        list<string> get_protocols() const NOEXCEPT;
     private:
         const curl_version_info_data *version;
     };
 
     // Implementation of get_host method.
-    inline const string curl_info::get_host() const NOEXCEPT {
+    inline string curl_info::get_host() const NOEXCEPT {
         return string(this->version->host);
     }
 
     // Implementation of get_ssl_version.
-    inline const string curl_info::get_ssl_version() const NOEXCEPT {
+    inline string curl_info::get_ssl_version() const NOEXCEPT {
         return string(this->version->ssl_version);
     }
 
     // Implementation of get_libz_version.
-    inline const string curl_info::get_libz_version() const NOEXCEPT {
+    inline string curl_info::get_libz_version() const NOEXCEPT {
         return string(this->version->libz_version);
     }
 
     // Implementation of get_ares method.
-    inline const string curl_info::get_ares() const NOEXCEPT {
+    inline string curl_info::get_ares() const NOEXCEPT {
         return string(this->version->ares);
     }
 
     // Implementation of get_libidin method.
-    inline const string curl_info::get_libidn() const NOEXCEPT {
+    inline string curl_info::get_libidn() const NOEXCEPT {
         return string(this->version->libidn);
     }
 
     // Implementation of get_libssh_version method.
-    inline const string curl_info::get_libssh_version() const NOEXCEPT {
+    inline string curl_info::get_libssh_version() const NOEXCEPT {
         return string(this->version->libssh_version);
     }
 
     // Implementation of get_version_number method.
-    inline const unsigned int curl_info::get_version_number() const NOEXCEPT {
+    inline unsigned int curl_info::get_version_number() const NOEXCEPT {
         return this->version->version_num;
     }
 
     // Implementation of get_features method.
-    inline const int curl_info::get_features() const NOEXCEPT {
+    inline int curl_info::get_features() const NOEXCEPT {
         return this->version->features;
     }
 
     // Implementation of get_ares_number method.
-    inline const int curl_info::get_ares_number() const NOEXCEPT {
+    inline int curl_info::get_ares_number() const NOEXCEPT {
         return this->version->ares_num;
     }
 
     // Implementation of get_iconv_version_number method.
-    inline const int curl_info::get_iconv_version_number() const NOEXCEPT {
+    inline int curl_info::get_iconv_version_number() const NOEXCEPT {
         return this->version->iconv_ver_num;
     }
 
     // Implementation of get_ssl_version_number method.
-    inline const long curl_info::get_ssl_version_number() const NOEXCEPT {
+    inline long curl_info::get_ssl_version_number() const NOEXCEPT {
         return this->version->ssl_version_num;
     }
 }

--- a/include/curl_multi.h
+++ b/include/curl_multi.h
@@ -62,12 +62,12 @@ namespace curl {
              * Inline getter method used to return
              * the message for a single handler.
              */
-            const CURLMSG get_message() const;
+            CURLMSG get_message() const;
             /**
              * Inline getter method used to return
              * the code for a single handler.
              */
-            const CURLcode get_code() const;
+            CURLcode get_code() const;
             /**
              * Inline getter method used to return
              * other data.
@@ -216,12 +216,12 @@ namespace curl {
     }
 
     // Implementation of curl_message get_message method.
-    inline const CURLMSG curl_multi::curl_message::get_message() const {
+    inline CURLMSG curl_multi::curl_message::get_message() const {
         return this->message;
     }
 
     // Implementation of curl_message get_code method.
-    inline const CURLcode curl_multi::curl_message::get_code() const {
+    inline CURLcode curl_multi::curl_message::get_code() const {
         return this->code;
     }
 

--- a/include/curl_pair.h
+++ b/include/curl_pair.h
@@ -57,13 +57,13 @@ namespace curl {
         /**
          * Simple method that returns the first field of the pair.
          */
-        inline const T first() const NOEXCEPT {
+        inline T first() const NOEXCEPT {
             return this->option;
         }
         /**
          * Simple method that returns the second field of the pair.
          */
-        inline const K second() const NOEXCEPT {
+        inline K second() const NOEXCEPT {
             return this->value;
         }
     private:
@@ -84,7 +84,7 @@ namespace curl {
         /**
          * Simple method that returns the first field of the pair.
          */
-        inline const CURLformoption first() const NOEXCEPT {
+        inline CURLformoption first() const NOEXCEPT {
             return this->option;
         }
         /**
@@ -115,7 +115,7 @@ namespace curl {
         /**
          * Simple method that returns the first field of the pair.
          */
-        inline const T first() const NOEXCEPT {
+        inline T first() const NOEXCEPT {
             return this->option;
         }
         /**
@@ -146,7 +146,7 @@ namespace curl {
         /**
          * Simple method that returns the first field of the pair.
          */
-        inline const T first() const NOEXCEPT {
+        inline T first() const NOEXCEPT {
             return this->option;
         }
         /**
@@ -177,7 +177,7 @@ namespace curl {
         /**
          * Simple method that returns the first field of the pair.
          */
-        inline const T first() const NOEXCEPT {
+        inline T first() const NOEXCEPT {
             return this->option;
         }
         /**

--- a/include/curl_receiver.h
+++ b/include/curl_receiver.h
@@ -57,7 +57,7 @@ namespace curl {
          * Simple getter method that returns the buffer with the received
          * data.
          */
-        const array<T,SIZE> get_buffer() const;
+        array<T,SIZE> get_buffer() const;
         /**
          * Simple getter method that returns the number of received bytes.
          * Real applications should check this number to ensure that the
@@ -89,7 +89,7 @@ namespace curl {
     }
     
     // Implementation of get_buffer method.
-    template<typename T, const size_t SIZE> inline const array<T,SIZE> curl_receiver<T,SIZE>::get_buffer() const {
+    template<typename T, const size_t SIZE> inline array<T,SIZE> curl_receiver<T,SIZE>::get_buffer() const {
         return _buffer;
     }
     

--- a/include/curl_share.h
+++ b/include/curl_share.h
@@ -85,7 +85,8 @@ namespace curl {
     }
 
     // Implementation of copy constructor.
-    inline curl_share::curl_share(const curl_share &share) {
+    inline curl_share::curl_share(const curl_share &share) : curl_interface() {
+    	(void)share; // unused
         curl_share();
     }
     

--- a/include/curl_utility.h
+++ b/include/curl_utility.h
@@ -28,7 +28,7 @@ namespace curl {
          * online documentation for more information about the datetime
          * parameter.
          */
-        static const time_t get_date(const string);
+        static time_t get_date(const string);
     private:
         /**
          * Build an object of this type have no sense. So let's hide
@@ -38,7 +38,7 @@ namespace curl {
     };
 
     // Implementation of get_date method.
-    const time_t curl_utility::get_date(const string format) {
+    time_t curl_utility::get_date(const string format) {
         const time_t value = curl_getdate(format.c_str(),nullptr);
         if (value == -1) {
             throw curl_exception("*** Error while parsing the date ***",__FUNCTION__);

--- a/src/curl_easy.cpp
+++ b/src/curl_easy.cpp
@@ -50,7 +50,7 @@ curl_easy::curl_easy(const long flag, curl_writer &writer) : curl_interface(flag
 }
 
 // Implementation of copy constructor to respect the rule of three.
-curl_easy::curl_easy(const curl_easy &easy) : curl(nullptr) {
+curl_easy::curl_easy(const curl_easy &easy) : curl_interface(), curl(nullptr) {
     *this = easy;
     // Let's use a duplication handle function provided by libcurl.
     this->curl = curl_easy_duphandle(easy.curl);

--- a/src/curl_info.cpp
+++ b/src/curl_info.cpp
@@ -18,7 +18,7 @@ curl_info::curl_info(const CURLversion version) {
 }
 
 // Implementation of get_protocols method.
-const list<string> curl_info::get_protocols() const NOEXCEPT {
+list<string> curl_info::get_protocols() const NOEXCEPT {
     list<string> protocols;
     const char *const *const prot = this->version->protocols;
     unsigned int i = 0;

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -23,7 +23,10 @@ curl_multi::curl_multi(const long flag) : curl_interface(flag) {
 }
 
 // Implementation of copy constructor to respect the rule of three.
-curl_multi::curl_multi(const curl_multi &multi) : message_queued(multi.message_queued), active_transfers(multi.active_transfers) {
+curl_multi::curl_multi(const curl_multi &multi)
+	: curl_interface(),
+	  message_queued(multi.message_queued),
+	  active_transfers(multi.active_transfers) {
     this->curl = curl_multi_init();
     if (this->curl == nullptr) {
         throw curl_multi_exception("Null pointer intercepted",__FUNCTION__);


### PR DESCRIPTION
I fixed the problems that created warnings when building with
`cmake . -DCMAKE_CXX_FLAGS='-std=c++11 -Wall -Wextra -Wpedantic -Wformat=2 -Wlogical-op -Wmissing-include-dirs -Wnon-virtual-dtor -Woverloaded-virtual -Wswitch-default -Wuninitialized -Wformat -Wformat-security' && make clean && make`
