### PR TITLE
Clean traceback after printing or returning it to the user

### DIFF
--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -84,11 +84,14 @@ namespace curl {
         for_each(curl_exception::traceback.begin(),curl_exception::traceback.end(),[](const pair<string,string> &value) {
             cout<<"ERROR: "<<value.first<<" ::::: FUNCTION: "<<value.second<<endl;
         });
+        curl_exception::traceback.clear();
     }
     
     // Implementation of get_traceback.
     inline vector<pair<string,string>> curl_exception::get_traceback() const {
-        return curl_exception::traceback;
+        auto copy = curl_exception::traceback;
+        curl_exception::traceback.clear();
+        return copy;
     }
     
     /**


### PR DESCRIPTION
Traceback defined as a static variable, and after each exception new data appended to old one. So after second (third, etc) exception we get not just the latest traceback, but also one from previous errors (which we already got!).
This fixes that weird behaviour by cleaning traceback after returning or printing it.