### PR TITLE
Get rid of MSVC c++11 warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,10 @@ set(CURLCPP_SOURCE
   curl_writer.cpp
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()


### PR DESCRIPTION
cl : Command line warning D9002 : ignoring unknown option '-std=c++11'

See also: http://stackoverflow.com/questions/29473786/command-line-warning-d9002-ignoring-unknown-option-std-c11