### PR TITLE
Improve exceptions

### DIFF
--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -57,7 +57,7 @@ namespace curl {
         /**
          * This constructor is used to build the error.
          */
-        curl_exception(const string, const string);
+        curl_exception(const string &error, const string &method);
         /**
          * The destructor, in this case, doesn't do anything.
          */
@@ -66,7 +66,7 @@ namespace curl {
         /**
          * Returns the vector of errors.
          */
-        vector<pair<string,string>> get_traceback() const;
+        vector<pair<string, string>> get_traceback() const;
         /**
          * Simple method which prints the entire error stack.
          */
@@ -88,7 +88,7 @@ namespace curl {
     }
     
     // Implementation of get_traceback.
-    inline vector<pair<string,string>> curl_exception::get_traceback() const {
+    inline vector<pair<string, string>> curl_exception::get_traceback() const {
         return traceback;
     }
     
@@ -102,11 +102,11 @@ namespace curl {
          * This constructor allows to specify a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_easy_exception(const string error, const string method) : curl_exception(error,method) {}
+        curl_easy_exception(const string &error, const string &method) : curl_exception(error, method) {}
         /**
          * The constructor will transform a CURLcode error in a proper error message.
          */
-        curl_easy_exception(const CURLcode code, const string method) : curl_exception(curl_easy_strerror(code),method) {}
+        curl_easy_exception(CURLcode code, const string &method) : curl_exception(curl_easy_strerror(code), method) {}
     };
     
     /**
@@ -119,11 +119,11 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_multi_exception(const string error, const string method) : curl_exception(error,method) {}
+        curl_multi_exception(const string &error, const string &method) : curl_exception(error, method) {}
         /**
          * The constructor will transform a CURLMcode error to a proper error message.
          */
-        curl_multi_exception(const CURLMcode code, const string method) : curl_exception(curl_multi_strerror(code),method) {}
+        curl_multi_exception(CURLMcode code, const string &method) : curl_exception(curl_multi_strerror(code), method) {}
     };
     
     /**
@@ -136,11 +136,11 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_share_exception(const string error, const string method) : curl_exception(error,method) {}
+        curl_share_exception(const string &error, const string &method) : curl_exception(error, method) {}
         /**
          * The constructor will transform a CURLSHcode error in a proper error message.
          */
-        curl_share_exception(const  CURLSHcode code, const string method) : curl_exception(curl_share_strerror(code),method) {}
+        curl_share_exception(CURLSHcode code, const string &method) : curl_exception(curl_share_strerror(code), method) {}
     };
 }
 

--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -72,23 +72,24 @@ namespace curl {
          */
         void print_traceback() const;
     private:
-        /**
-         * The error container must be static or will be cleared
-         * when an exception is thrown.
-         */
-        static vector<pair<string,string>> traceback;
+        vector<pair<string, string>> traceback;
     };
 
     // Implementation of print_traceback
     inline void curl_exception::print_traceback() const {
-        for_each(curl_exception::traceback.begin(),curl_exception::traceback.end(),[](const pair<string,string> &value) {
-            cout<<"ERROR: "<<value.first<<" ::::: FUNCTION: "<<value.second<<endl;
+        for_each(
+            traceback.begin(),
+            traceback.end(),
+            [](const pair<string, string> &value) {
+                cout << "ERROR: " << value.first
+                     << " ::::: FUNCTION: " << value.second
+                     << endl;
         });
     }
     
     // Implementation of get_traceback.
     inline vector<pair<string,string>> curl_exception::get_traceback() const {
-        return curl_exception::traceback;
+        return traceback;
     }
     
     /**

--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -102,11 +102,19 @@ namespace curl {
          * This constructor allows to specify a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_easy_exception(const string &error, const string &method) : curl_exception(error, method) {}
+        curl_easy_exception(const string &error, const string &method) : curl_exception(error, method), code(CURLE_OK) {}
         /**
          * The constructor will transform a CURLcode error in a proper error message.
          */
-        curl_easy_exception(CURLcode code, const string &method) : curl_exception(curl_easy_strerror(code), method) {}
+        curl_easy_exception(CURLcode code, const string &method) : curl_exception(curl_easy_strerror(code), method), code(code) {}
+        /**
+         * Returns the error code if there is one. Returns CURLE_OK if none has been set.
+         */
+        inline CURLcode get_code() const {
+            return code;
+        }
+    private:
+        CURLcode code;
     };
     
     /**
@@ -119,11 +127,19 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_multi_exception(const string &error, const string &method) : curl_exception(error, method) {}
+        curl_multi_exception(const string &error, const string &method) : curl_exception(error, method), code(CURLM_OK) {}
         /**
          * The constructor will transform a CURLMcode error to a proper error message.
          */
-        curl_multi_exception(CURLMcode code, const string &method) : curl_exception(curl_multi_strerror(code), method) {}
+        curl_multi_exception(CURLMcode code, const string &method) : curl_exception(curl_multi_strerror(code), method), code(code) {}
+        /**
+         * Returns the error code if there is one. Returns CURLM_OK if none has been set.
+         */
+        inline CURLMcode get_code() const {
+            return code;
+        }
+    private:
+        CURLMcode code;
     };
     
     /**
@@ -136,11 +152,19 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_share_exception(const string &error, const string &method) : curl_exception(error, method) {}
+        curl_share_exception(const string &error, const string &method) : curl_exception(error, method), code(CURLSHE_OK) {}
         /**
          * The constructor will transform a CURLSHcode error in a proper error message.
          */
-        curl_share_exception(CURLSHcode code, const string &method) : curl_exception(curl_share_strerror(code), method) {}
+        curl_share_exception(CURLSHcode code, const string &method) : curl_exception(curl_share_strerror(code), method), code(code) {}
+        /**
+         * Returns the error code if there is one. Returns CURLSHE_OK if none has been set.
+         */
+        inline CURLSHcode get_code() const {
+            return code;
+        }
+    private:
+        CURLSHcode code;
     };
 }
 

--- a/src/curl_exception.cpp
+++ b/src/curl_exception.cpp
@@ -7,12 +7,11 @@
 
 using curl::curl_exception;
 
-// Need to define the traceback here to separate declaration from definition, or we'll get a linker error.
-vector<pair<string,string>> curl::curl_exception::traceback;
-
 // Constructor implementation. Every call will push into the calls stack the function name and the error occurred.
 curl_exception::curl_exception(const string error, const string fun_name) {
-    curl_exception::traceback.insert(curl_exception::traceback.begin(),pair<string,string>(error,fun_name));
+    traceback.insert(
+        traceback.begin(),
+        pair<string, string>(error, fun_name));
 }
 
 // Implementation of destructor.

--- a/src/curl_exception.cpp
+++ b/src/curl_exception.cpp
@@ -8,10 +8,10 @@
 using curl::curl_exception;
 
 // Constructor implementation. Every call will push into the calls stack the function name and the error occurred.
-curl_exception::curl_exception(const string error, const string fun_name) {
+curl_exception::curl_exception(const string &error, const string &method) {
     traceback.insert(
         traceback.begin(),
-        pair<string, string>(error, fun_name));
+        pair<string, string>(error, method));
 }
 
 // Implementation of destructor.


### PR DESCRIPTION
1) Make curl_exception::traceback non-static. Contrary to what is said in the original comments, it should be no problem to make it non-static. I had no problems using this version for some weeks now.

2) Store error code in exceptions, so that we can use it when handling the exception.

Additionally there are some more cosmetic changes.