### PR TITLE
Improvements to thread safety.

### DIFF
--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -31,16 +31,15 @@
 #include <memory>
 
 #include "curl_config.h"
-#include "curl_interface.h"
 #include "curl_pair.h"
 #include "curl_writer.h"
+#include "curl_exception.h"
 
 using std::for_each;
 using std::unique_ptr;
 
 using curl::curl_pair;
 using curl::curl_writer;
-using curl::curl_interface;
 using curl::curl_easy_exception;
 
 #define CURLCPP_DEFINE_OPTION(opt, value_type)\
@@ -879,7 +878,7 @@ namespace curl  {
      * You don't have to worry about freeing data or things like
      * that. The class will do it for you.
      */
-    class curl_easy : public curl_interface<CURLcode> {
+    class curl_easy {
     public:
         /**
          * The default constructor will initialize the easy handler
@@ -892,16 +891,6 @@ namespace curl  {
          * operations.
          */
         explicit curl_easy(curl_writer &);
-        /**
-         * This overloaded constructor allows users to specify a flag
-         * used to initialize libcurl environment.
-         */
-        explicit curl_easy(const long);
-        /**
-         * This overloaded constructor specifies the environment
-         * initialization flags and an output stream for the libcurl output.
-         */
-        curl_easy(const long, curl_writer &);
         /**
          * Copy constructor to handle pointer copy. Internally, it uses
          * a function which duplicates the easy handler.

--- a/include/curl_global.h
+++ b/include/curl_global.h
@@ -2,7 +2,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2014 - Giuseppe Persico
- * File - curl_interface.h
+ * File - curl_global.h
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,42 +23,39 @@
  * SOFTWARE.
  */
 
-#ifndef __curlcpp__curl_interface__
-#define __curlcpp__curl_interface__
+#ifndef __curlcpp__curl_global__
+#define __curlcpp__curl_global__
 
 #include <curl/curl.h>
 #include "curl_exception.h"
 
-using curl::curl_exception;
-
 namespace curl {
     /**
-     * This class is a common interface for all the libcurl interfaces:
-     * easy, multi and share. It provides methods that these three interfaces
-     * have in common with each other.
+     * This class provides global initialization of curl so that use of all curl
+     * interfaces is thread safe.
      */
-    template<class T> class curl_interface {
-    protected:
+    class curl_global {
+    public:
         /**
          * The default constructor will initialize the curl
          * environment with the default flag.
          */
-        curl_interface();
+        curl_global();
         /**
          * Overloaded constructor that initializes curl environment
          * with user specified flag.
          */
-        explicit curl_interface(const long);
+        explicit curl_global(const long);
         /**
          * The virtual destructor will provide an easy and clean
          * way to deallocate resources, closing curl environment
          * correctly.
          */
-        virtual ~curl_interface();
+        virtual ~curl_global();
     };
     
     // Implementation of constructor.
-    template<class T> curl_interface<T>::curl_interface() {
+    curl_global::curl_global() {
         const CURLcode code = curl_global_init(CURL_GLOBAL_ALL);
         if (code != CURLE_OK) {
             throw curl_easy_exception(code,__FUNCTION__);
@@ -66,7 +63,7 @@ namespace curl {
     }
     
     // Implementation of overloaded constructor.
-    template<class T> curl_interface<T>::curl_interface(const long flag) {
+    curl_global::curl_global(const long flag) {
         const CURLcode code = curl_global_init(flag);
         if (code != CURLE_OK) {
             throw curl_easy_exception(code,__FUNCTION__);
@@ -74,9 +71,9 @@ namespace curl {
     }
     
     // Implementation of the virtual destructor.
-    template<class T> curl_interface<T>::~curl_interface() {
+    curl_global::~curl_global() {
         curl_global_cleanup();
     }
 }
 
-#endif	/* defined(__curlcpp__curl_interface__) */
+#endif	/* defined(__curlcpp__curl_global__) */

--- a/include/curl_multi.h
+++ b/include/curl_multi.h
@@ -42,7 +42,7 @@ namespace curl {
      * 3. Enable the application to wait for action on its own file descriptors and curl's
      *    file descriptors simultaneous easily.
     */
-    class curl_multi : public curl_interface<CURLMcode> {
+    class curl_multi {
     public:
         /**
          * The multi interface gives users the opportunity to get information about
@@ -86,12 +86,6 @@ namespace curl {
          * values.
          */
         curl_multi();
-        /**
-         * Overloaded constructor. Gives users the opportunity
-         * to initialize the entire curl environment using custom
-         * options.
-         */
-        explicit curl_multi(const long);
         /**
          * Copy constructor to perform a correct copy of the curl 
          * handler and attributes.

--- a/include/curl_share.h
+++ b/include/curl_share.h
@@ -26,10 +26,10 @@
 #ifndef __curlcpp__curl_share__
 #define __curlcpp__curl_share__
 
-#include "curl_interface.h"
+#include <curl/curl.h>
 #include "curl_pair.h"
+#include "curl_exception.h"
 
-using curl::curl_interface;
 using curl::curl_pair;
 using curl::curl_share_exception;
 
@@ -38,19 +38,13 @@ namespace curl {
      * Definition of share interface. The purpose of this interface is to
      * enable data sharing between curl handlers.
      */
-    class curl_share : public curl_interface<CURLSHcode> {
+    class curl_share {
     public:
         /**
          * The default constructor will initialize the share
          * handle to its default value.
          */
         curl_share();
-        /**
-         * The overloaded constructor allows users to initialize
-         * the share handle and initialize the libcurl environment
-         * using customs flags.
-         */
-        explicit curl_share(const long);
         /**
          * Copy constructor to perform the copy of the share handle.
          */ 
@@ -79,13 +73,8 @@ namespace curl {
         CURLSH *curl;
     };
 
-    // Implementation of overloaded constructor.
-    inline curl_share::curl_share(const long flag) : curl_interface(flag) {
-        curl_share();
-    }
-
     // Implementation of copy constructor.
-    inline curl_share::curl_share(const curl_share &share) : curl_interface() {
+    inline curl_share::curl_share(const curl_share &share) {
     	(void)share; // unused
         curl_share();
     }

--- a/src/curl_easy.cpp
+++ b/src/curl_easy.cpp
@@ -8,7 +8,7 @@
 using curl::curl_easy;
 
 // Implementation of default constructor.
-curl_easy::curl_easy() : curl_interface() {
+curl_easy::curl_easy() {
     this->curl = curl_easy_init();
     if (this->curl == nullptr) {
         throw curl_easy_exception("Null pointer intercepted",__FUNCTION__);
@@ -19,7 +19,7 @@ curl_easy::curl_easy() : curl_interface() {
 }
 
 // Implementation of default constructor.
-curl_easy::curl_easy(curl_writer &writer) : curl_interface() {
+curl_easy::curl_easy(curl_writer &writer) {
     this->curl = curl_easy_init();
     if (this->curl == nullptr) {
         throw curl_easy_exception("Null pointer intercepted",__FUNCTION__);
@@ -28,29 +28,8 @@ curl_easy::curl_easy(curl_writer &writer) : curl_interface() {
     this->add(curl_pair<CURLoption,void*>(CURLOPT_WRITEDATA, static_cast<void*>(writer.get_stream())));
 }
 
-// Implementation of overridden constructor.
-curl_easy::curl_easy(const long flag) : curl_interface(flag) {
-    this->curl = curl_easy_init();
-    if (this->curl == nullptr) {
-        throw curl_easy_exception("Null pointer intercepted",__FUNCTION__);
-    }
-    curl_writer writer;
-    this->add(curl_pair<CURLoption,curlcpp_writer_type>(CURLOPT_WRITEFUNCTION,writer.get_function()));
-    this->add(curl_pair<CURLoption,void *>(CURLOPT_WRITEDATA, static_cast<void*>(writer.get_stream())));
-}
-
-// Implementation of overridden constructor.
-curl_easy::curl_easy(const long flag, curl_writer &writer) : curl_interface(flag) {
-    this->curl = curl_easy_init();
-    if (this->curl == nullptr) {
-        throw curl_easy_exception("Null pointer intercepted",__FUNCTION__);
-    }
-    this->add(curl_pair<CURLoption, size_t(*)(void*,size_t,size_t,void*)>(CURLOPT_WRITEFUNCTION,writer.get_function()));
-    this->add(curl_pair<CURLoption, void*>(CURLOPT_WRITEDATA, static_cast<void*>(writer.get_stream())));
-}
-
 // Implementation of copy constructor to respect the rule of three.
-curl_easy::curl_easy(const curl_easy &easy) : curl_interface(), curl(nullptr) {
+curl_easy::curl_easy(const curl_easy &easy) : curl(nullptr) {
     *this = easy;
     // Let's use a duplication handle function provided by libcurl.
     this->curl = curl_easy_duphandle(easy.curl);

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -8,7 +8,7 @@
 using curl::curl_multi;
 
 // Implementation of constructor.
-curl_multi::curl_multi() : curl_interface() {
+curl_multi::curl_multi() {
     this->curl = curl_multi_init();
     if (this->curl == nullptr) {
         throw curl_multi_exception("Null pointer intercepted",__FUNCTION__);
@@ -17,15 +17,9 @@ curl_multi::curl_multi() : curl_interface() {
     this->message_queued = 0;
 }
 
-// Implementation of overloaded constructor.
-curl_multi::curl_multi(const long flag) : curl_interface(flag) {
-    curl_multi();
-}
-
 // Implementation of copy constructor to respect the rule of three.
 curl_multi::curl_multi(const curl_multi &multi)
-	: curl_interface(),
-	  message_queued(multi.message_queued),
+	: message_queued(multi.message_queued),
 	  active_transfers(multi.active_transfers) {
     this->curl = curl_multi_init();
     if (this->curl == nullptr) {

--- a/src/curl_share.cpp
+++ b/src/curl_share.cpp
@@ -8,7 +8,7 @@
 using curl::curl_share;
 
 // Implementation of default constructor.
-curl_share::curl_share() : curl_interface() {
+curl_share::curl_share() {
     this->curl = curl_share_init();
     if (this->curl == nullptr) {
         throw curl_share_exception("Null pointer intercepted",__FUNCTION__);


### PR DESCRIPTION
The curl_global_init and curl_global_cleanup functions are not thread safe.  The
curl_easy, curl_multi, and curl_share interfaces inherit from curl_interface, a
class that calls these functions in the constructor and destructor.
Furthermore, the curl_interface class does not provide any common functions
besides constructors and destructors that call these unsafe global init and
cleanup functions.

Since it is not useful for polymorphism and negates thread safety, I removed the
curl_interface parent class entirely, replacing it with a standalone curl_global
class.  This new class  provides RAII functionality for curl_global_init and
curl_global_cleanup, improving the library's thread safety while also
simplifying the inheritance structure.

If neither thread safety nor application-specific init flags are required, it is
not necessary to use the curl_global class.  The underlying curl library will
call curl_global_init automatically.

If either thread safety or application-specific init flags are required, simply
declare a single instance of curl_global at the appropriate point in your
program.

Old code that supplies init flags to the curl_easy, curl_multi, and curl_share
constructors must be updated to supply the flags to an instance of curl_global
instead.  All other code will continue to work as before.