### PR TITLE
Added curl_reader class (analogous to curl_writer)

### DIFF
--- a/include/curl_reader.h
+++ b/include/curl_reader.h
@@ -1,0 +1,87 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 - Giuseppe Persico
+ * File - curl_reader.h
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef __curlcpp__curl_reader__
+#define __curlcpp__curl_reader__
+
+#include <iostream>
+
+using std::istream;
+
+// Let's typedef this big boy to enhance code readability.
+typedef size_t (*curlcpp_reader_type)(void *, size_t, size_t, void *);
+
+namespace curl {
+    /**
+     * This class allows users to specify a stream from which libcurl can read
+     * input.  The curl_easy class will set all the necessary options to make it
+     * easy. You just have to specify your stream and your reader function.
+     */
+    class curl_reader {
+    public:
+        /**
+         * The default constructor will use a default stream and a default
+         * reader callback to perform the operations.
+         */
+        curl_reader();
+        /**
+         * This overloaded constructor allows users to specify a stream
+         * from which to read, using the default reader callback.
+         */
+        curl_reader(istream &);
+        /**
+         * This overloaded constructor allows users to specify a reader
+         * callback function used to specify how to write something on
+         * the default stream (which is std::cin)
+         */
+        curl_reader(curlcpp_reader_type);
+        /**
+         * This overloaded constructor allows users to specify a custom
+         * stream and a custom reader callback function.
+         */
+        curl_reader(istream &, curlcpp_reader_type);
+        /**
+         * Simple getter method that returns the stream specified in the
+         * constructor.
+         */
+        istream *get_stream() const;
+        /**
+         * Simple getter method that returns the function specified (or not)
+         * in the constructor.
+         */
+        curlcpp_reader_type get_function() const;
+    protected:
+        /**
+         * Utility method used to validate the function pointer eventually
+         * specified.
+         */
+        void set_reader_ptr(curlcpp_reader_type);
+    private:
+        curlcpp_reader_type _reader_ptr;
+        istream *_stream_ptr;
+    };
+}
+
+#endif /* defined(__curlcpp__curl_reader__) */

--- a/src/curl_reader.cpp
+++ b/src/curl_reader.cpp
@@ -1,0 +1,58 @@
+/**
+ * File:   curl_reader.cpp
+ * Author: Giuseppe Persico
+ */
+
+#include "curl_reader.h"
+
+using std::cin;
+using curl::curl_reader;
+
+// Default memory read callback.
+namespace {
+    size_t read_memory_callback(void *contents, size_t size, size_t nmemb, void *userp) {
+        const size_t realsize = size * nmemb;
+        istream* const mem = static_cast<istream*>(userp);
+        mem->read(static_cast<char*>(contents), realsize);
+        return mem->gcount();
+    }
+}
+
+// Implementation of constructor.
+curl_reader::curl_reader() {
+    _stream_ptr = &cin;
+    _reader_ptr = &read_memory_callback;
+}
+
+// Implementation of overloaded constructor.
+curl_reader::curl_reader(istream &stream) {
+    _stream_ptr = &stream;
+    _reader_ptr = &read_memory_callback;
+}
+
+// Implementation of another overloaded constructor.
+curl_reader::curl_reader(curlcpp_reader_type reader_ptr) {
+    _stream_ptr = &cin;
+    this->set_reader_ptr(reader_ptr);
+}
+
+// Implementation of another overloaded constructor.
+curl_reader::curl_reader(istream &stream, curlcpp_reader_type reader_ptr) {
+    _stream_ptr = &stream;
+    this->set_reader_ptr(reader_ptr);
+}
+
+// Implementation of get_stream method.
+istream *curl_reader::get_stream() const {
+    return _stream_ptr;
+}
+
+// Implementation of get_function method.
+curlcpp_reader_type curl_reader::get_function() const {
+    return _reader_ptr;
+}
+
+// Implementation of set_reader_ptr method.
+void curl_reader::set_reader_ptr(curlcpp_reader_type reader_ptr) {
+    _reader_ptr = (reader_ptr == nullptr) ? &read_memory_callback : reader_ptr;
+}


### PR DESCRIPTION
This class is intended for use with CURLOPT_READFUNCTION and CURLOPT_READDATA.
For example:

```
std::stringstream uploadStream;
uploadStream.str("Hey Hey Hey!");

curl_easy easy;
curl_reader uploadReader(uploadStream);

easy.add(curl_pair<CURLoption,curlcpp_reader_type>(
            CURLOPT_READFUNCTION, uploadReader.get_function()));
easy.add(curl_pair<CURLoption,void*>(
            CURLOPT_READDATA, static_cast<void*>(uploadReader.get_stream())));
```