### PR TITLE
Add get_curl method to curl_multi::curl_message.

### DIFF
--- a/include/curl_multi.h
+++ b/include/curl_multi.h
@@ -65,6 +65,11 @@ namespace curl {
             CURLMSG get_message() const;
             /**
              * Inline getter method used to return
+             * the curl handle.
+             */
+            const CURL *get_curl() const;
+            /**
+             * Inline getter method used to return
              * the code for a single handler.
              */
             CURLcode get_code() const;
@@ -75,6 +80,7 @@ namespace curl {
             const void *get_other() const;
         private:
             const CURLMSG message;
+            const CURL *curl;
             const void *whatever;
             const CURLcode code;
         };
@@ -212,6 +218,11 @@ namespace curl {
     // Implementation of curl_message get_message method.
     inline CURLMSG curl_multi::curl_message::get_message() const {
         return this->message;
+    }
+
+    // Implementation of curl_message get_curl method.
+    inline const CURL *curl_multi::curl_message::get_curl() const {
+        return this->curl;
     }
 
     // Implementation of curl_message get_code method.

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -148,6 +148,6 @@ void curl_multi::timeout(long *timeout) {
 
 // Implementation of curl_message constructor.
 curl_multi::curl_message::curl_message(const CURLMsg *msg) :
-    message(msg->msg), whatever(msg->data.whatever), code(msg->data.result) {
+    message(msg->msg), curl(msg->easy_handle), whatever(msg->data.whatever), code(msg->data.result) {
     // ... nothing to do here ...
 }


### PR DESCRIPTION
This enables code as follows, rather than needing to call
curl_multi::is_finished(curl_easy &) for each curl_easy:

```c++
unordered_map<const CURL*,curl_easy> conns;
curl_multi multi;
...
for (auto &conn : conns) {
    multi.add(conn.second);
}
...
multi.perform();
for (auto msg : multi.get_info()) {
    if (msg->get_message() == CURLMSG_DONE) {
        multi.remove(conns[msg->get_curl()]);
        conns.erase(msg->get_curl();
    }
}
```