### PR TITLE
Remove using

### DIFF
--- a/include/curl_cookie.h
+++ b/include/curl_cookie.h
@@ -27,6 +27,7 @@
 #define curl_cookie_h
 
 #include <string>
+#include <vector>
 #include <ostream>
 #include "curl_easy.h"
 
@@ -36,10 +37,8 @@
  * allocation and deallocation.
  */
 namespace curl {
-	using curlcpp_cookies = vector<string>;
+	using curlcpp_cookies = std::vector<std::string>;
 
-	using std::string;
-   	using std::ostringstream;
 
     class curl_cookie {
 
@@ -54,7 +53,7 @@ namespace curl {
          * If you pass an empty string or a string containing a non existing file's path, 
          * the cookie engine will be initialized, but without reading initial cookies.
          */
-        void set_cookie_file(const string) NOEXCEPT;
+        void set_cookie_file(const std::string) NOEXCEPT;
         /**
          * This method allow you to specify a file where libcurl will write every internal
          * known-stored cookie when the curl_easy destructor will be called. If no cookies
@@ -62,19 +61,19 @@ namespace curl {
          * this session, so if you for example follow a location it will make matching cookies
          * get sent accordingly.
          */
-        void set_cookiejar_file(const string) NOEXCEPT;
+        void set_cookiejar_file(const std::string) NOEXCEPT;
         /**
          * This method allow you to specify a string that represents a cookie. Such a cookie 
          * can be either a single line in Netscape / Mozilla format or just regular HTTP-style
          * header (Set-Cookie: ...) format. This will also enable the cookie engine. This adds
          * that single cookie to the internal cookie store.
          */
-        void set_cookie_list(const string) NOEXCEPT;
+        void set_cookie_list(const std::string) NOEXCEPT;
         void set_cookie_list(const char *) NOEXCEPT;
         // This method overloads the one previously declared allowing to specify a vector of cookies.
-        void set_cookie_list(const vector<string> &) NOEXCEPT;
+        void set_cookie_list(const std::vector<std::string> &) NOEXCEPT;
         // This method overloads the one previously declared allowing to specifiy a stream of cookies.
-        void set_cookie_list(const ostringstream) NOEXCEPT;
+        void set_cookie_list(const std::ostringstream) NOEXCEPT;
         // This method erases all cookies held in memory.
         void erase() NOEXCEPT;
         // This method writes all the cookies held in memory to the file specifiied with set_cookiejar_file method.

--- a/include/curl_cookie.h
+++ b/include/curl_cookie.h
@@ -30,21 +30,22 @@
 #include <ostream>
 #include "curl_easy.h"
 
-using std::string;
-using std::ostringstream;
-using curl::curl_easy;
-
-using curlcpp_cookies = vector<string>;
-
 /**
  * This class represents a generic cookie handler. It allows a user to get
  * and set cookie for a domain, in an easy way and without caring about resources
  * allocation and deallocation.
  */
 namespace curl {
+	using curlcpp_cookies = vector<string>;
+
+	using std::string;
+   	using std::ostringstream;
+
     class curl_cookie {
+
     public:
-        // This constructor allow you to specify a curl_easy object.
+
+   		// This constructor allow you to specify a curl_easy object.
         curl_cookie(curl_easy &easy) : easy(easy) {}
         // This method allow you to get all known cookies for a specific domain.
         const curlcpp_cookies get() const NOEXCEPT;

--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -35,13 +35,7 @@
 #include "curl_pair.h"
 #include "curl_ios.h"
 
-using std::for_each;
 using std::unique_ptr;
-
-using curl::curl_pair;
-using curl::curl_ios;
-using curl::curl_interface;
-using curl::curl_easy_exception;
 
 #define CURLCPP_DEFINE_OPTION(opt, value_type)\
     template <> struct option_t<opt> {\
@@ -49,6 +43,8 @@ using curl::curl_easy_exception;
     }
 
 namespace curl  {
+	using std::for_each;
+
     namespace detail {
         template <CURLoption>
         struct option_t;

--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -35,7 +35,6 @@
 #include "curl_pair.h"
 #include "curl_ios.h"
 
-using std::unique_ptr;
 
 #define CURLCPP_DEFINE_OPTION(opt, value_type)\
     template <> struct option_t<opt> {\
@@ -43,7 +42,6 @@ using std::unique_ptr;
     }
 
 namespace curl  {
-	using std::for_each;
 
     namespace detail {
         template <CURLoption>

--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -942,12 +942,12 @@ namespace curl  {
          * This function converts the given input string to an URL encoded
          * string and returns a newly allocated string.
          */
-        void escape(string &);
+        void escape(std::string &);
         /**
          * This function converts the given URL encoded input string to a
          * "plain string" and returns a newly allocated string.
          */
-        void unescape(string &);
+        void unescape(std::string &);
         /**
          * This function performs all the operations a user has specified
          * with the add methods. If the performing operation has finished

--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -36,20 +36,24 @@
 
 #include "curl_config.h"
 
-using std::cout;
-using std::endl;
-using std::string;
-using std::exception;
-using std::pair;
-using std::vector;
-using std::for_each;
 
-// We like it short.
-using curlcpp_traceback_object = pair<string,string>;
-using curlcpp_traceback = vector<curlcpp_traceback_object>;
+
 
 namespace curl {
-    /**
+
+	using std::cout;
+	using std::endl;
+	using std::string;
+	using std::exception;
+	using std::pair;
+	using std::vector;
+	using std::for_each;
+
+	// We like it short.
+	using curlcpp_traceback_object = pair<string,string>;
+	using curlcpp_traceback = vector<curlcpp_traceback_object>;
+
+	/**
      * This class represents a custom exception for libcurl errors. 
      * If a function throws an error, its name will be added to a
      * vector (treated like a stack, because if I had used a stack,
@@ -58,6 +62,7 @@ namespace curl {
      */
     class curl_exception : public exception {
     public:
+
         /**
          * This constructor is used to build the error.
          */

--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -36,22 +36,12 @@
 
 #include "curl_config.h"
 
-
-
-
 namespace curl {
 
-	using std::cout;
-	using std::endl;
-	using std::string;
-	using std::exception;
-	using std::pair;
-	using std::vector;
-	using std::for_each;
 
 	// We like it short.
-	using curlcpp_traceback_object = pair<string,string>;
-	using curlcpp_traceback = vector<curlcpp_traceback_object>;
+	using curlcpp_traceback_object = std::pair<std::string,std::string>;
+	using curlcpp_traceback = std::vector<curlcpp_traceback_object>;
 
 	/**
      * This class represents a custom exception for libcurl errors. 
@@ -60,18 +50,18 @@ namespace curl {
      * to print it, I should have to remove all the elements), so
      * users can keep track of which method threw which exception.
      */
-    class curl_exception : public exception {
+    class curl_exception : public std::exception {
     public:
 
         /**
          * This constructor is used to build the error.
          */
-        curl_exception(const string, const string);
+        curl_exception(const std::string, const std::string);
         /**
          * The destructor, in this case, doesn't do anything.
          */
         ~curl_exception() NOEXCEPT;
-        using exception::what;
+        using std::exception::what;
         /**
          * Returns the vector of errors.
          */
@@ -90,8 +80,8 @@ namespace curl {
 
     // Implementation of print_traceback
     inline void curl_exception::print_traceback() const {
-        for_each(curl_exception::traceback.begin(),curl_exception::traceback.end(),[](const curlcpp_traceback_object &value) {
-            cout<<"ERROR: "<<value.first<<" ::::: FUNCTION: "<<value.second<<endl;
+        std::for_each(curl_exception::traceback.begin(),curl_exception::traceback.end(),[](const curlcpp_traceback_object &value) {
+            std::cout<<"ERROR: "<<value.first<<" ::::: FUNCTION: "<<value.second<<std::endl;
         });
     }
     
@@ -110,11 +100,11 @@ namespace curl {
          * This constructor allows to specify a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_easy_exception(const string error, const string method) : curl_exception(error,method) {}
+        curl_easy_exception(const std::string error, const std::string method) : curl_exception(error,method) {}
         /**
          * The constructor will transform a CURLcode error in a proper error message.
          */
-        curl_easy_exception(const CURLcode code, const string method) : curl_exception(curl_easy_strerror(code),method) {}
+        curl_easy_exception(const CURLcode code, const std::string method) : curl_exception(curl_easy_strerror(code),method) {}
     };
     
     /**
@@ -127,11 +117,11 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_multi_exception(const string error, const string method) : curl_exception(error,method) {}
+        curl_multi_exception(const std::string error, const std::string method) : curl_exception(error,method) {}
         /**
          * The constructor will transform a CURLMcode error to a proper error message.
          */
-        curl_multi_exception(const CURLMcode code, const string method) : curl_exception(curl_multi_strerror(code),method) {}
+        curl_multi_exception(const CURLMcode code, const std::string method) : curl_exception(curl_multi_strerror(code),method) {}
     };
     
     /**
@@ -144,11 +134,11 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_share_exception(const string error, const string method) : curl_exception(error,method) {}
+        curl_share_exception(const std::string error, const std::string method) : curl_exception(error,method) {}
         /**
          * The constructor will transform a CURLSHcode error in a proper error message.
          */
-        curl_share_exception(const  CURLSHcode code, const string method) : curl_exception(curl_share_strerror(code),method) {}
+        curl_share_exception(const  CURLSHcode code, const std::string method) : curl_exception(curl_share_strerror(code),method) {}
     };
 }
 

--- a/include/curl_form.h
+++ b/include/curl_form.h
@@ -34,12 +34,11 @@
 #include "curl_exception.h"
 #include "curl_pair.h"
 
-using std::vector;
-using std::bad_alloc;
-using curl::curl_pair;
-using curl::curl_exception;
-
 namespace curl {
+
+	using std::vector;
+	using std::bad_alloc;
+
     /**
      * This class simplifies the creation of a form. It wraps all the libcurl
      * functions used to add content to a form and to destroy it.

--- a/include/curl_form.h
+++ b/include/curl_form.h
@@ -36,9 +36,6 @@
 
 namespace curl {
 
-	using std::vector;
-	using std::bad_alloc;
-
     /**
      * This class simplifies the creation of a form. It wraps all the libcurl
      * functions used to add content to a form and to destroy it.
@@ -69,31 +66,31 @@ namespace curl {
          * This method allows users to add content to a form, using the
          * curl_pair class.
          */
-        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &);
+        void add(const curl_pair<CURLformoption,std::string> &, const curl_pair<CURLformoption,std::string> &);
         /**
          * Overloaded add method.
          */
-        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &);
+        void add(const curl_pair<CURLformoption,std::string> &, const curl_pair<CURLformoption,std::string> &, const curl_pair<CURLformoption,std::string> &);
         /**
          * Overloaded add method. It adds another curl_pair object to add more
          * contents to the form contents list.
          */
-        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,int> &);
+        void add(const curl_pair<CURLformoption,std::string> &, const curl_pair<CURLformoption,std::string> &, const curl_pair<CURLformoption,int> &);
         /**
          * Overloaded add method. It adds another curl_pair object to add more
          * contents to the form contents list.
          */
-        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,int> &, const curl_pair<CURLformoption,string> &);
+        void add(const curl_pair<CURLformoption,std::string> &, const curl_pair<CURLformoption,int> &, const curl_pair<CURLformoption,std::string> &);
         /**
          * Overloaded add method. It adds another curl_pair object to add more
          * contents to the form contents list.
          */
-        void add(const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,string> &, const curl_pair<CURLformoption,int> &, const curl_pair<CURLformoption,string> &);
+        void add(const curl_pair<CURLformoption,std::string> &, const curl_pair<CURLformoption,std::string> &, const curl_pair<CURLformoption,int> &, const curl_pair<CURLformoption,std::string> &);
         /**
          * Overloaded add method. This version is primarily used to upload multiple files.
          * You can pass a vector of filenames to upload them.
          */
-        void add(const curl_pair<CURLformoption,string> &, const vector<string> &);
+        void add(const curl_pair<CURLformoption,std::string> &, const std::vector<std::string> &);
         /**
          * Simple getter method used to return the head of the list.
          */
@@ -124,7 +121,7 @@ namespace curl {
     // Implementation of utility function to check if a pointer points to null.
     template<typename T> inline void curl_form::is_null(const T *ptr) const {
         if (ptr == nullptr) {
-            throw bad_alloc();
+            throw std::bad_alloc();
         }
     }
 

--- a/include/curl_header.h
+++ b/include/curl_header.h
@@ -32,10 +32,10 @@
 
 #include "curl_config.h"
 
-using std::string;
-using std::initializer_list;
-
 namespace curl {
+	using std::string;
+	using std::initializer_list;
+
     /**
      * This class represents a generic header. It allows a user to add
      * headers without caring about deallocation of resources.

--- a/include/curl_header.h
+++ b/include/curl_header.h
@@ -33,8 +33,6 @@
 #include "curl_config.h"
 
 namespace curl {
-	using std::string;
-	using std::initializer_list;
 
     /**
      * This class represents a generic header. It allows a user to add
@@ -51,7 +49,7 @@ namespace curl {
          * Overloaded constructor that allows users to initialize the
          * headers list with a list of values.
          */
-        curl_header(initializer_list<string>);
+        curl_header(std::initializer_list<std::string>);
         /**
          * Copy constructor. Performs a deep copy of the headers list.
          */
@@ -69,7 +67,7 @@ namespace curl {
         /**
          * This method allows users to add a header as string.
          */
-        void add(const string);
+        void add(const std::string);
         /**
          * This method allows users to add headers specifying an iterable
          * data structure containing the headers to add.

--- a/include/curl_info.h
+++ b/include/curl_info.h
@@ -32,10 +32,10 @@
 
 #include "curl_config.h"
 
-using std::string;
-using std::list;
-
 namespace curl {
+	using std::string;
+	using std::list;
+
     /**
      * This class represents a structure that provides information about various
      * features in the running version of libcurl.

--- a/include/curl_info.h
+++ b/include/curl_info.h
@@ -33,8 +33,6 @@
 #include "curl_config.h"
 
 namespace curl {
-	using std::string;
-	using std::list;
 
     /**
      * This class represents a structure that provides information about various
@@ -56,30 +54,30 @@ namespace curl {
          * Returns a string that shows what host information that this
          * libcurl was built for.
          */
-        string get_host() const NOEXCEPT;
+        std::string get_host() const NOEXCEPT;
         /**
          * Returns a string for the OpenSSL version used. If libcurl has no
          * SSL support, the method returns null.
          */
-        string get_ssl_version() const NOEXCEPT;
+        std::string get_ssl_version() const NOEXCEPT;
         /**
          * Returns a string for libz compression library version. If libcurl
          * has no libz support, the method returns null.
          */
-        string get_libz_version() const NOEXCEPT;
+        std::string get_libz_version() const NOEXCEPT;
         /**
          * No description supplied for this method.
          */
-        string get_ares() const NOEXCEPT;
+        std::string get_ares() const NOEXCEPT;
         /**
          * No description supplied for this method.
          */
-        string get_libidn() const NOEXCEPT;
+        std::string get_libidn() const NOEXCEPT;
         /**
          * Returns a string for libssh library version. If libcurl
          * has no libssh support, the method returns null.
          */
-        string get_libssh_version() const NOEXCEPT;
+        std::string get_libssh_version() const NOEXCEPT;
         /**
          * Returns the version number.
          */
@@ -104,39 +102,39 @@ namespace curl {
          * Returns a list of all the protocols supported in the
          * running version of libcurl library.
          */
-        list<string> get_protocols() const NOEXCEPT;
+        std::list<std::string> get_protocols() const NOEXCEPT;
     private:
         const curl_version_info_data *version;
     };
 
     // Implementation of get_host method.
-    inline string curl_info::get_host() const NOEXCEPT {
-        return string(this->version->host);
+    inline std::string curl_info::get_host() const NOEXCEPT {
+        return std::string(this->version->host);
     }
 
     // Implementation of get_ssl_version.
-    inline string curl_info::get_ssl_version() const NOEXCEPT {
-        return string(this->version->ssl_version);
+    inline std::string curl_info::get_ssl_version() const NOEXCEPT {
+        return std::string(this->version->ssl_version);
     }
 
     // Implementation of get_libz_version.
-    inline string curl_info::get_libz_version() const NOEXCEPT {
-        return string(this->version->libz_version);
+    inline std::string curl_info::get_libz_version() const NOEXCEPT {
+        return std::string(this->version->libz_version);
     }
 
     // Implementation of get_ares method.
-    inline string curl_info::get_ares() const NOEXCEPT {
-        return string(this->version->ares);
+    inline std::string curl_info::get_ares() const NOEXCEPT {
+        return std::string(this->version->ares);
     }
 
     // Implementation of get_libidin method.
-    inline string curl_info::get_libidn() const NOEXCEPT {
-        return string(this->version->libidn);
+    inline std::string curl_info::get_libidn() const NOEXCEPT {
+        return std::string(this->version->libidn);
     }
 
     // Implementation of get_libssh_version method.
-    inline string curl_info::get_libssh_version() const NOEXCEPT {
-        return string(this->version->libssh_version);
+    inline std::string curl_info::get_libssh_version() const NOEXCEPT {
+        return std::string(this->version->libssh_version);
     }
 
     // Implementation of get_version_number method.

--- a/include/curl_interface.h
+++ b/include/curl_interface.h
@@ -29,8 +29,6 @@
 #include <curl/curl.h>
 #include "curl_exception.h"
 
-using curl::curl_exception;
-
 namespace curl {
     /**
      * This class is a common interface for all the libcurl interfaces:

--- a/include/curl_ios.h
+++ b/include/curl_ios.h
@@ -37,7 +37,6 @@
 using curlcpp_callback_type = size_t(*)(void *,size_t,size_t,void *);
 
 namespace {
-	//TODO can be moved inside the namespace?
 
     // Default in-memory write callback.
     size_t write_memory_callback(void *contents, size_t size, size_t nmemb, void *userp) {
@@ -63,12 +62,6 @@ namespace {
 }
 
 namespace curl {
-	using std::ostream;
-	using std::istream;
-	using std::string;
-	using std::cout;
-	using std::cin;
-	using std::ostringstream;
 
     template<class T> class curl_ios {
     public:
@@ -96,18 +89,18 @@ namespace curl {
     };
     
     // Template specialization for ostream class.
-    template<> class curl_ios<ostream> {
+    template<> class curl_ios<std::ostream> {
     public:
         // This constructor will initialize the stream with cout and the callback with a default in-memory write callback.
-        curl_ios() : _callback_ptr(write_memory_callback), _io_stream(&cout) {}
+        curl_ios() : _callback_ptr(write_memory_callback), _io_stream(&std::cout) {}
         // This constructor will initialize the stream with a customized stream and a default in-memory write callback.
-        curl_ios(ostream &io_stream) : _callback_ptr(write_memory_callback), _io_stream(&io_stream) {}
+        curl_ios(std::ostream &io_stream) : _callback_ptr(write_memory_callback), _io_stream(&io_stream) {}
         // This constructor will initialize the stream with cout and a customized write callback.
-        curl_ios(curlcpp_callback_type callback_ptr) : _io_stream(&cout) {
+        curl_ios(curlcpp_callback_type callback_ptr) : _io_stream(&std::cout) {
             this->set_callback(callback_ptr);
         }
         // This constructor will initialize the the stream with a custom stream and the callback with a customized one.
-        curl_ios(ostream &io_stream, curlcpp_callback_type callback_ptr) : _io_stream(&io_stream) {
+        curl_ios(std::ostream &io_stream, curlcpp_callback_type callback_ptr) : _io_stream(&io_stream) {
             this->set_callback(callback_ptr);
         }
         // This method allow to specify a custom callback pointer.
@@ -115,7 +108,7 @@ namespace curl {
             _callback_ptr = callback_ptr == nullptr ? write_variable_callback : callback_ptr;
         }
         // This method returns the stream pointer.
-        ostream *get_stream() const {
+        std::ostream *get_stream() const {
             return this->_io_stream;
         }
         // This method returns the callback for this curl_ios.
@@ -126,16 +119,16 @@ namespace curl {
         // The callback pointer.
         curlcpp_callback_type _callback_ptr;
         // A stream pointer.
-        ostream *_io_stream;
+        std::ostream *_io_stream;
     };
     
     // Template specialization for ostringstream class.
-    template<> class curl_ios<ostringstream> {
+    template<> class curl_ios<std::ostringstream> {
     public:
         //This constructor allows to specify a custom ostringstream stream.
-        curl_ios(ostringstream &o_stream) : _callback_ptr(write_variable_callback), _o_stream(&o_stream) {}
+        curl_ios(std::ostringstream &o_stream) : _callback_ptr(write_variable_callback), _o_stream(&o_stream) {}
         //This constructor allows to specify a custom stream and a custom callback pointer.
-        curl_ios(ostringstream &o_stream, curlcpp_callback_type callback_ptr) {
+        curl_ios(std::ostringstream &o_stream, curlcpp_callback_type callback_ptr) {
             _o_stream = &o_stream;
             this->set_callback(callback_ptr);
         }
@@ -144,7 +137,7 @@ namespace curl {
             _callback_ptr = callback_ptr == nullptr ? write_variable_callback : callback_ptr;
         }
         // This method returns the stream pointer.
-        ostringstream *get_stream() const {
+        std::ostringstream *get_stream() const {
             return this->_o_stream;
         }
         // This method returns the callback pointer.
@@ -155,25 +148,25 @@ namespace curl {
         // The callback pointer.
         curlcpp_callback_type _callback_ptr;
         // The ostringstream pointer.
-        ostringstream *_o_stream;
+        std::ostringstream *_o_stream;
     };
     
     
     // Template specialization for istream class.
-    template<> class curl_ios<istream> {
+    template<> class curl_ios<std::istream> {
     public:
         // The default constructor will initialize the callback pointer and the stream with default values.
-        curl_ios() : _callback_ptr(read_memory_callback), _i_stream(&cin) {}
+        curl_ios() : _callback_ptr(read_memory_callback), _i_stream(&std::cin) {}
         //This constructor allows to specify an input stream while the a default callback pointer will be used.
-        curl_ios(istream &i_stream) : _callback_ptr(read_memory_callback) {
+        curl_ios(std::istream &i_stream) : _callback_ptr(read_memory_callback) {
             _i_stream = &i_stream;
         }
         // This overloaded constructor allows to specify a custom callback pointer while the stream will be cin.
-        curl_ios(curlcpp_callback_type callback_ptr) : _i_stream(&cin) {
+        curl_ios(curlcpp_callback_type callback_ptr) : _i_stream(&std::cin) {
             this->set_callback(callback_ptr);
         }
         // This method allows to specify a custom stream and a custom callback pointer.
-        curl_ios(istream &i_stream, curlcpp_callback_type callback_ptr) : _i_stream(&i_stream) {
+        curl_ios(std::istream &i_stream, curlcpp_callback_type callback_ptr) : _i_stream(&i_stream) {
             this->set_callback(callback_ptr);
         }
         // This method allows to specify a custom callback pointer.
@@ -181,7 +174,7 @@ namespace curl {
             _callback_ptr = callback_ptr == nullptr ? write_variable_callback : callback_ptr;
         }
         // This method returns the stream pointer.
-        istream *get_stream() const {
+        std::istream *get_stream() const {
             return _i_stream;
         }
         // This method returns the callback pointer.
@@ -192,7 +185,7 @@ namespace curl {
         // The callback pointer.
         curlcpp_callback_type _callback_ptr;
         // The stream pointer.
-        istream *_i_stream;
+        std::istream *_i_stream;
     };
 }
 

--- a/include/curl_ios.h
+++ b/include/curl_ios.h
@@ -31,41 +31,45 @@
 #include <string>
 #include <sstream>
 
-using std::ostream;
-using std::istream;
-using std::string;
-using std::cout;
-using std::cin;
-using std::ostringstream;
+
 
 // Let's typedef this big boy to enhance code readability.
 using curlcpp_callback_type = size_t(*)(void *,size_t,size_t,void *);
 
 namespace {
+	//TODO can be moved inside the namespace?
+
     // Default in-memory write callback.
     size_t write_memory_callback(void *contents, size_t size, size_t nmemb, void *userp) {
         const size_t realsize = size * nmemb;
-        ostream* const mem = static_cast<ostream*>(userp);
+        std::ostream* const mem = static_cast<std::ostream*>(userp);
         mem->write(static_cast<const char*>(contents), realsize);
         return realsize;
     }
     // Default in-variable write callback.
     size_t write_variable_callback(void *contents, size_t size, size_t nmemb, void *userp) {
         const size_t realsize = size * nmemb;
-        std::ostringstream *stream = static_cast<ostringstream*>(userp);
+        std::ostringstream *stream = static_cast<std::ostringstream*>(userp);
         stream->write(static_cast<const char *>(contents), realsize);
         return realsize;
     }
     // Default in-memory read callback.
     size_t read_memory_callback(void *contents, size_t size, size_t nmemb, void *userp) {
         const size_t realsize = size * nmemb;
-        istream* const mem = static_cast<istream*>(userp);
+        std::istream* const mem = static_cast<std::istream*>(userp);
         mem->read(static_cast<char*>(contents), realsize);
         return mem->gcount();
     }
 }
 
 namespace curl {
+	using std::ostream;
+	using std::istream;
+	using std::string;
+	using std::cout;
+	using std::cin;
+	using std::ostringstream;
+
     template<class T> class curl_ios {
     public:
         // This constructor allows to specifiy a custom stream and a custom callback pointer.

--- a/include/curl_multi.h
+++ b/include/curl_multi.h
@@ -26,12 +26,13 @@
 #ifndef __curlcpp__curl_multi__
 #define __curlcpp__curl_multi__
 
+#include <memory>
 #include "curl_easy.h"
 
-using curl::curl_easy;
-using curl::curl_multi_exception;
-
 namespace curl {
+
+	using std::unique_ptr;
+
     /**
      * As libcurl documentation says, the multi interface offers several abilities that
      * the easy interface doesn't. They are mainly:

--- a/include/curl_multi.h
+++ b/include/curl_multi.h
@@ -27,11 +27,11 @@
 #define __curlcpp__curl_multi__
 
 #include <memory>
+#include <vector>
+
 #include "curl_easy.h"
 
 namespace curl {
-
-	using std::unique_ptr;
 
     /**
      * As libcurl documentation says, the multi interface offers several abilities that
@@ -133,12 +133,12 @@ namespace curl {
          * This method tries to obtain information about all the handlers added
          * to the multi handler.
          */
-        vector<unique_ptr<curl_message>> get_info();
+        std::vector<std::unique_ptr<curl_message>> get_info();
         /**
          * This method tries to obtain information regarding an easy handler 
          * that has been added to the multi handler.
          */
-        unique_ptr<curl_message> get_info(const curl_easy &);
+        std::unique_ptr<curl_message> get_info(const curl_easy &);
         /**
          * This method checks if the transfer on a curl_easy object is finished.
          */

--- a/include/curl_pair.h
+++ b/include/curl_pair.h
@@ -29,17 +29,13 @@
 #include <string>
 #include "curl_config.h"
 
-// Forward reference to curl_form and curl_header
 namespace curl {
+	using std::string;
+
+	// Forward reference to curl_form and curl_header
     class curl_form;
     class curl_header;
-}
 
-using std::string;
-using curl::curl_form;
-using curl::curl_header;
-
-namespace curl {
     /**
      * This is a class that wraps two objects: an option and the value for
      * that option. It's very useful when building forms or setting options

--- a/include/curl_pair.h
+++ b/include/curl_pair.h
@@ -30,7 +30,6 @@
 #include "curl_config.h"
 
 namespace curl {
-	using std::string;
 
 	// Forward reference to curl_form and curl_header
     class curl_form;
@@ -69,13 +68,13 @@ namespace curl {
     /**
      * Template specialization for C++ strings and CURLformoption.
      */
-    template<> class curl_pair<CURLformoption,string> {
+    template<> class curl_pair<CURLformoption,std::string> {
     public:
         /**
          * The two parameters constructor gives users a fast way to
          * build an object of this type.
          */
-        curl_pair(const CURLformoption option, const string &value) : option(option), value(value) {}
+        curl_pair(const CURLformoption option, const std::string &value) : option(option), value(value) {}
         /**
          * Simple method that returns the first field of the pair.
          */
@@ -91,7 +90,7 @@ namespace curl {
         }
     private:
         const CURLformoption option;
-        const string &value;
+        const std::string &value;
     };
         
     /**
@@ -100,13 +99,13 @@ namespace curl {
      * handle C++ string type, so we can specialize curl_pair class in a
      * manner that its methods returns a const char *.
      */
-    template<class T> class curl_pair<T,string> {
+    template<class T> class curl_pair<T,std::string> {
     public:
         /**
          * The two parameters constructor gives users a fast way to 
          * build an object of this type.
          */
-        curl_pair(const T option, const string &value) : option(option == CURLOPT_POSTFIELDS ? CURLOPT_COPYPOSTFIELDS : option), value(value) {};
+        curl_pair(const T option, const std::string &value) : option(option == CURLOPT_POSTFIELDS ? CURLOPT_COPYPOSTFIELDS : option), value(value) {};
         /**
          * Simple method that returns the first field of the pair.
          */
@@ -122,7 +121,7 @@ namespace curl {
         }
     private:
         const T option;
-        const string &value;
+        const std::string &value;
     };
     
     /**

--- a/include/curl_receiver.h
+++ b/include/curl_receiver.h
@@ -29,10 +29,10 @@
 #include <array>
 #include "curl_easy.h"
 
-using std::array;
-using curl::curl_easy;
-
 namespace curl {
+
+	using std::array;
+
     /**
      * This class implements a receiver that allow users to receive raw
      * data on an established connection on an easy handler.

--- a/include/curl_receiver.h
+++ b/include/curl_receiver.h
@@ -31,8 +31,6 @@
 
 namespace curl {
 
-	using std::array;
-
     /**
      * This class implements a receiver that allow users to receive raw
      * data on an established connection on an easy handler.
@@ -57,7 +55,7 @@ namespace curl {
          * Simple getter method that returns the buffer with the received
          * data.
          */
-        array<T,SIZE> get_buffer() const;
+        std::array<T,SIZE> get_buffer() const;
         /**
          * Simple getter method that returns the number of received bytes.
          * Real applications should check this number to ensure that the
@@ -65,7 +63,7 @@ namespace curl {
          */
         size_t get_received_bytes() const;
     private:
-        array<T,SIZE> _buffer;
+        std::array<T,SIZE> _buffer;
         size_t _recv_bytes;
     };
     
@@ -89,7 +87,7 @@ namespace curl {
     }
     
     // Implementation of get_buffer method.
-    template<typename T, const size_t SIZE> inline array<T,SIZE> curl_receiver<T,SIZE>::get_buffer() const {
+    template<typename T, const size_t SIZE> inline std::array<T,SIZE> curl_receiver<T,SIZE>::get_buffer() const {
         return _buffer;
     }
     

--- a/include/curl_sender.h
+++ b/include/curl_sender.h
@@ -77,7 +77,7 @@ namespace curl {
      * functions, so we must treat it as a const char pointer. This is the purpose of
      * this class.
      */
-    template<> class curl_sender<string> {
+    template<> class curl_sender<std::string> {
     public:
         /**
          * The constructor initializes the easy handler and the number of
@@ -89,7 +89,7 @@ namespace curl {
          * on an established connection on an easy handler, treating strings
          * as const char pointers.
          */
-        void send(const string buffer) {
+        void send(const std::string buffer) {
             const CURLcode code = curl_easy_send(_easy.get_curl(),buffer.c_str(),buffer.length(),&_sent_bytes);
             if (code != CURLE_OK) {
                 throw curl_easy_exception(code,__FUNCTION__);

--- a/include/curl_sender.h
+++ b/include/curl_sender.h
@@ -28,8 +28,6 @@
 
 #include "curl_easy.h"
 
-using curl::curl_easy;
-
 namespace curl {
     /**
      * This class implements a sender that sends raw data on an established

--- a/include/curl_share.h
+++ b/include/curl_share.h
@@ -29,10 +29,6 @@
 #include "curl_interface.h"
 #include "curl_pair.h"
 
-using curl::curl_interface;
-using curl::curl_pair;
-using curl::curl_share_exception;
-
 namespace curl {
     /**
      * Definition of share interface. The purpose of this interface is to

--- a/include/curl_utility.h
+++ b/include/curl_utility.h
@@ -11,10 +11,8 @@
 #include <string>
 #include "curl_exception.h"
 
-using std::string;
-using curl::curl_exception;
-
 namespace curl {
+	using std::string;
     /**
      * This class provides some utilities that are unrelated to
      * the libcurl interfaces, so they are enclosed in this class.

--- a/include/curl_utility.h
+++ b/include/curl_utility.h
@@ -12,7 +12,6 @@
 #include "curl_exception.h"
 
 namespace curl {
-	using std::string;
     /**
      * This class provides some utilities that are unrelated to
      * the libcurl interfaces, so they are enclosed in this class.
@@ -26,7 +25,7 @@ namespace curl {
          * online documentation for more information about the datetime
          * parameter.
          */
-        static time_t get_date(const string);
+        static time_t get_date(const std::string);
     private:
         /**
          * Build an object of this type have no sense. So let's hide
@@ -36,7 +35,7 @@ namespace curl {
     };
 
     // Implementation of get_date method.
-    time_t curl_utility::get_date(const string format) {
+    time_t curl_utility::get_date(const std::string format) {
         const time_t value = curl_getdate(format.c_str(),nullptr);
         if (value == -1) {
             throw curl_exception("*** Error while parsing the date ***",__FUNCTION__);

--- a/src/curl_cookie.cpp
+++ b/src/curl_cookie.cpp
@@ -3,9 +3,14 @@
  * Author: Giuseppe Persico
  */
 
+#include <vector>
+
 #include "curl_cookie.h"
 
+using std::vector;
+
 namespace curl {
+
     // Implementation of the get method.
     const curlcpp_cookies curl_cookie::get() const NOEXCEPT {
         vector<string> cookies;

--- a/src/curl_cookie.cpp
+++ b/src/curl_cookie.cpp
@@ -8,6 +8,8 @@
 #include "curl_cookie.h"
 
 using std::vector;
+using std::string;
+using std::ostringstream;
 
 namespace curl {
 

--- a/src/curl_easy.cpp
+++ b/src/curl_easy.cpp
@@ -6,6 +6,8 @@
 #include "curl_easy.h"
 
 using curl::curl_easy;
+using std::ostream;
+using std::string;
 
 // Implementation of default constructor.
 curl_easy::curl_easy() : curl_interface() {

--- a/src/curl_exception.cpp
+++ b/src/curl_exception.cpp
@@ -12,7 +12,7 @@ using curl::curlcpp_traceback;
 curlcpp_traceback curl::curl_exception::traceback;
 
 // Constructor implementation. Every call will push into the calls stack the function name and the error occurred.
-curl_exception::curl_exception(const string error, const string fun_name) {
+curl_exception::curl_exception(const std::string error, const std::string fun_name) {
     curl_exception::traceback.insert(curl_exception::traceback.begin(),curlcpp_traceback_object(error,fun_name));
 }
 

--- a/src/curl_exception.cpp
+++ b/src/curl_exception.cpp
@@ -6,6 +6,7 @@
 #include "curl_exception.h"
 
 using curl::curl_exception;
+using curl::curlcpp_traceback;
 
 // Need to define the traceback here to separate declaration from definition, or we'll get a linker error.
 curlcpp_traceback curl::curl_exception::traceback;

--- a/src/curl_form.cpp
+++ b/src/curl_form.cpp
@@ -8,6 +8,10 @@
 
 using curl::curl_form;
 
+using std::string;
+using std::vector;
+using std::bad_alloc;
+
 // Implementation of constructor.
 curl_form::curl_form() : form_post(nullptr), last_ptr(nullptr) {
     // ... nothing to do here ...

--- a/src/curl_header.cpp
+++ b/src/curl_header.cpp
@@ -7,9 +7,13 @@
 #include "curl_exception.h"
 #include <algorithm>
 
+using std::string;
+using std::initializer_list;
 using std::for_each;
+
 using curl::curl_header;
 using curl::curl_exception;
+
 
 // Implementation of constructor.
 curl_header::curl_header() : size(0), headers(nullptr) {

--- a/src/curl_info.cpp
+++ b/src/curl_info.cpp
@@ -6,6 +6,9 @@
 #include "curl_info.h"
 
 using curl::curl_info;
+using std::string;
+using std::list;
+
 
 // Implementation of default constructor.
 curl_info::curl_info() {

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -6,6 +6,7 @@
 #include "curl_multi.h"
 
 using curl::curl_multi;
+using std::vector;
 
 // Implementation of constructor.
 curl_multi::curl_multi() : curl_interface() {

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -7,6 +7,7 @@
 
 using curl::curl_multi;
 using std::vector;
+using std::unique_ptr;
 
 // Implementation of constructor.
 curl_multi::curl_multi() : curl_interface() {

--- a/test/cookie.cpp
+++ b/test/cookie.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "curl_easy.h"
 #include "curl_exception.h"
 #include "curl_form.h"
@@ -5,8 +7,10 @@
 
 using curl::curl_header;
 using curl::curl_easy;
-using curl::curl_exception;
+using curl::curl_easy_exception;
 using curl::curl_cookie;
+using curl::curlcpp_cookies;
+
 
 /*
  * This example shows to how to set and get cookies in a
@@ -36,7 +40,7 @@ int main() {
     }
     // Now let's print them
     for (auto cook : cookies) {
-        cout<<cook<<endl;
+        std::cout<<cook<<std::endl;
     }
     return 0;
 }

--- a/test/easy.cpp
+++ b/test/easy.cpp
@@ -1,6 +1,7 @@
 #include "curl_easy.h"
 
 using curl::curl_easy;
+using curl::curl_easy_exception;
 
 /*
  * This example shows how to make a simple request with

--- a/test/header.cpp
+++ b/test/header.cpp
@@ -4,6 +4,8 @@
 
 using curl::curl_header;
 using curl::curl_easy;
+using curl::curl_easy_exception;
+using curl::curlcpp_traceback;
 
 /*
  * This example shows how to add custom headers to a simple

--- a/test/recv_header.cpp
+++ b/test/recv_header.cpp
@@ -3,6 +3,7 @@
 
 using curl::curl_easy;
 using curl::curl_ios;
+using curl::curl_easy_exception;
 using std::ostringstream;
 
 /*
@@ -39,6 +40,6 @@ int main() {
     }
 
     // Let's print ONLY the headers.
-    cout<<header_var.str()<<endl;
+    std::cout<<header_var.str()<<std::endl;
     return 0;
 }


### PR DESCRIPTION
this commit resolve #60,
I removed all the "using" inside the .h files.
note that this break some example application. but I think that now there is a more consistent api since you must specify the namespace if you want use a class inside the curl namespace.
before the curl_easy_exception was automatically exported in the main namespace. 