### PR TITLE
add minimal install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+build/
 blocks/
 bii/build
 bii/cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 IF(BIICODE)
     INCLUDE(biicode/cmake/tools)
-    
+
     ACTIVATE_CPP11()
     ADD_BIICODE_TARGETS()
 ELSE()
@@ -22,6 +22,9 @@ ELSE()
     # Set up include pathes
     include_directories(${CURL_INCLUDE_DIRS}
       ${CURLCPP_SOURCE_DIR}/include)
+
+    file(GLOB HEADER_LIST "${CMAKE_SOURCE_DIR}/include/*.h")
+    install (FILES ${HEADER_LIST} DESTINATION include)
 
     # Set up source directories
     add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,5 +17,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 
-add_library(curlcpp STATIC ${CURLCPP_SOURCE})
+add_library(curlcpp ${CURLCPP_SOURCE})
 target_link_libraries(curlcpp ${CURL_LIBRARY})
+install (TARGETS curlcpp LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)


### PR DESCRIPTION
lack of install target makes current cmake config not so friendly for system-wide installation
also there is no need to force static build, cmake should default to static build and explicitly setting target to static makes it impossible to build a shared library