### PR TITLE
Use By-Reference rather then By-Value for objects like strings.

### DIFF
--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -917,7 +917,7 @@ namespace curl  {
          * Allows users to specify an option for the current easy handler,
          * using a curl_pair object.
          */
-        template<typename T> void add(const curl_pair<CURLoption,T>);
+        template<typename T> void add(const curl_pair<CURLoption,T>&);
         
         /**
          * Allows users to specify a list of options for the current
@@ -1002,7 +1002,7 @@ namespace curl  {
     }
     
     // Implementation of add method.
-    template<typename T> void curl_easy::add(const curl_pair<CURLoption,T> pair) {
+    template<typename T> void curl_easy::add(const curl_pair<CURLoption,T>& pair) {
         const CURLcode code = curl_easy_setopt(this->curl,pair.first(),pair.second());
         if (code != CURLE_OK) {
             throw curl_easy_exception(code,__FUNCTION__);

--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -56,7 +56,7 @@ namespace curl {
         /**
          * This constructor is used to build the error.
          */
-        curl_exception(const std::string, const std::string);
+        curl_exception(const std::string&, const std::string&);
         /**
          * The destructor, in this case, doesn't do anything.
          */
@@ -100,11 +100,11 @@ namespace curl {
          * This constructor allows to specify a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_easy_exception(const std::string error, const std::string method) : curl_exception(error,method) {}
+        curl_easy_exception(const std::string &error, const std::string &method) : curl_exception(error,method) {}
         /**
          * The constructor will transform a CURLcode error in a proper error message.
          */
-        curl_easy_exception(const CURLcode code, const std::string method) : curl_exception(curl_easy_strerror(code),method) {}
+        curl_easy_exception(const CURLcode &code, const std::string &method) : curl_exception(curl_easy_strerror(code),method) {}
     };
     
     /**
@@ -117,11 +117,11 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_multi_exception(const std::string error, const std::string method) : curl_exception(error,method) {}
+        curl_multi_exception(const std::string &error, const std::string &method) : curl_exception(error,method) {}
         /**
          * The constructor will transform a CURLMcode error to a proper error message.
          */
-        curl_multi_exception(const CURLMcode code, const std::string method) : curl_exception(curl_multi_strerror(code),method) {}
+        curl_multi_exception(const CURLMcode code, const std::string &method) : curl_exception(curl_multi_strerror(code),method) {}
     };
     
     /**
@@ -134,11 +134,11 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_share_exception(const std::string error, const std::string method) : curl_exception(error,method) {}
+        curl_share_exception(const std::string &error, const std::string &method) : curl_exception(error,method) {}
         /**
          * The constructor will transform a CURLSHcode error in a proper error message.
          */
-        curl_share_exception(const  CURLSHcode code, const std::string method) : curl_exception(curl_share_strerror(code),method) {}
+        curl_share_exception(const  CURLSHcode code, const std::string &method) : curl_exception(curl_share_strerror(code),method) {}
     };
 }
 

--- a/include/curl_option.h
+++ b/include/curl_option.h
@@ -29,14 +29,14 @@
 namespace curl {    
     template <class V>
     inline curl_pair<CURLoption, V> 
-        make_option(const CURLoption opt, const V& val)
+        make_option(const CURLoption opt, const V &val)
     {
         return curl_pair<CURLoption, V>(opt, val);
     }
     
     template <class V>
     inline curl_pair<CURLformoption, V>
-        make_formoption(const CURLformoption opt, const V& val)
+        make_formoption(const CURLformoption opt, const V &val)
     {
         return curl_pair<CURLformoption, V>(opt, val);
     }

--- a/src/curl_exception.cpp
+++ b/src/curl_exception.cpp
@@ -12,7 +12,7 @@ using curl::curlcpp_traceback;
 curlcpp_traceback curl::curl_exception::traceback;
 
 // Constructor implementation. Every call will push into the calls stack the function name and the error occurred.
-curl_exception::curl_exception(const std::string error, const std::string fun_name) {
+curl_exception::curl_exception(const std::string &error, const std::string &fun_name) {
     curl_exception::traceback.insert(curl_exception::traceback.begin(),curlcpp_traceback_object(error,fun_name));
 }
 


### PR DESCRIPTION
Often it is recommended to use references, this is often faster.