### PR TITLE
curl_global_init and curl_global_cleanup should be called only once

### DIFF
--- a/include/curl_global.h
+++ b/include/curl_global.h
@@ -72,7 +72,6 @@ namespace curl {
     
     // Implementation of the virtual destructor.
     curl_global::~curl_global() {
-        curl_global_cleanup();
     }
 }
 

--- a/include/curl_interface.h
+++ b/include/curl_interface.h
@@ -53,26 +53,57 @@ namespace curl {
          * correctly.
          */
         virtual ~curl_interface();
+
+    private:
+        /**
+         * This struct is used for initializing curl only once
+         * it is implemented as a singleton pattern
+         */
+        struct global_initialisator {
+            explicit global_initialisator(const long);
+            ~global_initialisator();
+        };
+
+        /**
+         * The singleton instance
+         */
+        static global_initialisator instance;
+
+        /**
+         * the singleton initialization, constructing a global_initialisator.
+         */
+        static void init(const long flag);
     };
     
     // Implementation of constructor.
     template<class T> curl_interface<T>::curl_interface() {
-        const CURLcode code = curl_global_init(CURL_GLOBAL_ALL);
-        if (code != CURLE_OK) {
-            throw curl_easy_exception(code,__FUNCTION__);
-        }
+        init(CURL_GLOBAL_ALL);
     }
     
     // Implementation of overloaded constructor.
     template<class T> curl_interface<T>::curl_interface(const long flag) {
+        init(flag);
+    }
+    
+    // Implementation of the virtual destructor.
+    template<class T> curl_interface<T>::~curl_interface() {
+    }
+
+    // Implementation of the static initialization function
+    template<class T> void curl_interface<T>::init(const long flag) {
+        static global_initialisator _instance {flag};
+    }
+
+    // Implementation of the singleton initalizator
+    template<class T> curl_interface<T>::global_initialisator::global_initialisator(const long flag) {
         const CURLcode code = curl_global_init(flag);
         if (code != CURLE_OK) {
             throw curl_easy_exception(code,__FUNCTION__);
         }
     }
-    
-    // Implementation of the virtual destructor.
-    template<class T> curl_interface<T>::~curl_interface() {
+
+    // Implementation of the singleton destructor
+    template<class T> curl_interface<T>::global_initialisator::~global_initialisator() {
         curl_global_cleanup();
     }
 }

--- a/include/curl_ios.h
+++ b/include/curl_ios.h
@@ -58,7 +58,7 @@ namespace curl {
     template<class T> class curl_ios {
     public:
         // This constructor allows to specifiy a custom stream and a custom callback pointer.
-        curl_ios(T &stream, curlcpp_callback_type callback_ptr) : _stream(stream) {
+        curl_ios(T *stream, curlcpp_callback_type callback_ptr) : _stream(stream) {
             this->set_callback(callback_ptr);
         }
         // This method allow to specify a custom callback pointer.


### PR DESCRIPTION
I get an error when trying to use openssl after having used curl_easy:
error:140A90F1:SSL routines:SSL_CTX_new:unable to load ssl2 md5 routines 

Apparently, calling curl_global_cleanup can have some side effect.

Calling curl_global_init and cleanup only once has stop the error from happening. 



