### PR TITLE
move constructor added to curl_easy

### DIFF
--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -896,6 +896,12 @@ namespace curl  {
          * a function which duplicates the easy handler.
          */
         curl_easy(const curl_easy &);
+        /**
+         * Move constructor that moves and easy handler from the other instance
+         * to this one.
+         * a function which duplicates the easy handler.
+         */
+        curl_easy(curl_easy &&);
         
         /**
          * Assignment operator used to perform assignment between objects

--- a/src/curl_easy.cpp
+++ b/src/curl_easy.cpp
@@ -40,6 +40,14 @@ curl_easy::curl_easy(const curl_easy &easy) : curl_interface(), curl(nullptr) {
     this->curl = curl_easy_duphandle(easy.curl);
 }
 
+// Implementation of move constructor
+curl_easy::curl_easy(curl_easy &&other) : curl_interface(), curl(nullptr) {
+    this->curl = other.curl;
+    // other's pointer set to nullptr so that the destructor doesn't call the
+    // cleanup function
+    other.curl = nullptr;
+}
+
 // Implementation of assignment operator to perform a deep copy.
 curl_easy &curl_easy::operator=(const curl_easy &easy) {
     if (this == &easy) {


### PR DESCRIPTION
A curl_easy object is now movable, that means that the curl handle is
not duped between instances but transfered.

This makes possible to store curl_easy instances in a vector; without
the move constructor, if a resize of the vector happens, the combo (copy
constructor + destructor) will be called cancelling any pending
transfer.