### PR TITLE
Misspellings of CURLINFO in curl_easy

### DIFF
--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -125,7 +125,7 @@ namespace curl  {
         // This option is avaiable in libcurl 7.45 or greater.
 #if defined(LIBCURL_VERSION_NUM) && LIBCURL_VERSION_NUM >= 0x072D00
         // The session's active socket.
-        CURLCPP_DEFINE_INFO(CURLINFO_ACTIVE_SOCKET,curl_socket_t *);
+        CURLCPP_DEFINE_INFO(CURLINFO_ACTIVESOCKET,curl_socket_t *);
 #endif
         // The entry path after logging in to an FTP server.
         CURLCPP_DEFINE_INFO(CURLINFO_FTP_ENTRY_PATH,char *);
@@ -133,11 +133,11 @@ namespace curl  {
         CURLCPP_DEFINE_INFO(CURLINFO_CERTINFO,struct curl_certinfo *);
         // This costant is avaiable with libcurl < 7.48
 #if defined(LIBCURL_VERSION_NUM) && LIBCURL_VERSION_NUM < 0x073000
-        // TSL session info that can be used for further processing.
+        // TLS session info that can be used for further processing.
         CURLCPP_DEFINE_INFO(CURLINFO_TLS_SESSION,struct curl_tlssessioninfo *);
 #else
-        // TSL session info that can be used for further processing.
-        CURLCPP_DEFINE_INFO(CURLINFO_TSL_SSL_PTR,struct curl_tlssessioninfo *);
+        // TLS session info that can be used for further processing.
+        CURLCPP_DEFINE_INFO(CURLINFO_TLS_SSL_PTR,struct curl_tlssessioninfo *);
 #endif
         // Whether or not a time conditional was met.
         CURLCPP_DEFINE_INFO(CURLINFO_CONDITION_UNMET,long);


### PR DESCRIPTION
These are some of the current errors I'm running into as I'm building curlcpp for Windows. I'm assuming these are misspellings of the CURLINFO types provided here: https://curl.haxx.se/libcurl/c/curl_easy_getinfo.html