### PR TITLE
Added back error codes to exceptions

### DIFF
--- a/include/curl_exception.h
+++ b/include/curl_exception.h
@@ -98,11 +98,21 @@ namespace curl {
          * This constructor allows to specify a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_easy_exception(const std::string &error, const std::string &method) : curl_exception(error,method) {}
+        curl_easy_exception(const std::string &error, const std::string &method) : curl_exception(error,method), code(CURLE_OK) {}
         /**
          * The constructor will transform a CURLcode error in a proper error message.
          */
-        curl_easy_exception(const CURLcode &code, const std::string &method) : curl_exception(curl_easy_strerror(code),method) {}
+        curl_easy_exception(const CURLcode &code, const std::string &method) : curl_exception(curl_easy_strerror(code),method), code(code) {}
+        
+        /**
+         * Returns the error code if there is one. Returns CURLE_OK if none has been set.
+         */
+        inline CURLcode get_code() const {
+            return code;
+        }
+        
+      private:
+        CURLcode code;
     };
     
     /**
@@ -115,11 +125,21 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_multi_exception(const std::string &error, const std::string &method) : curl_exception(error,method) {}
+        curl_multi_exception(const std::string &error, const std::string &method) : curl_exception(error,method), code(CURLM_OK) {}
         /**
          * The constructor will transform a CURLMcode error to a proper error message.
          */
-        curl_multi_exception(const CURLMcode code, const std::string &method) : curl_exception(curl_multi_strerror(code),method) {}
+        curl_multi_exception(const CURLMcode code, const std::string &method) : curl_exception(curl_multi_strerror(code),method), code(code) {}
+        
+        /**
+         * Returns the error code if there is one. Returns CURLM_OK if none has been set.
+         */
+        inline CURLMcode get_code() const {
+            return code;
+        }
+        
+      private:
+        CURLMcode code;
     };
     
     /**
@@ -132,11 +152,21 @@ namespace curl {
          * This constructor enables setting a custom error message and the method name where
          * the exception has been thrown.
          */
-        curl_share_exception(const std::string &error, const std::string &method) : curl_exception(error,method) {}
+        curl_share_exception(const std::string &error, const std::string &method) : curl_exception(error,method), code(CURLSHE_OK) {}
         /**
          * The constructor will transform a CURLSHcode error in a proper error message.
          */
-        curl_share_exception(const  CURLSHcode code, const std::string &method) : curl_exception(curl_share_strerror(code),method) {}
+        curl_share_exception(const  CURLSHcode code, const std::string &method) : curl_exception(curl_share_strerror(code),method), code(code) {}
+        
+        /**
+         * Returns the error code if there is one. Returns CURLE_OK if none has been set.
+         */
+        inline CURLSHcode get_code() const {
+            return code;
+        }
+        
+      private:
+          CURLSHcode code;
     };
 }
 


### PR DESCRIPTION
This functionality was originally present in 0dd4bae0a0f0b8a5ec385b70a9d864a338d891b9 and then removed in ca71ff519bb625bec7840980fdd187c5408f3372.