### PR TITLE
fix a wrong parameter in a string constructor

### DIFF
--- a/include/curl_easy_info.h
+++ b/include/curl_easy_info.h
@@ -52,7 +52,7 @@ namespace curl {
         curl_easy_info(char *pointer) : _pointer(pointer) {}
         std::string get() const {
             if (_pointer == nullptr) {
-                return std::string('');
+                return std::string("");
             }
             return std::string(_pointer);
         }


### PR DESCRIPTION
Hi,
Thanks for developing curlcpp.
This PR fixes a wrong parameter in a string constructor (`''` should be `""`), which prevents compiling on some systems.