### PR TITLE
Disabled copying for curl_global, added curl_global_cleanup call

### DIFF
--- a/include/curl_global.h
+++ b/include/curl_global.h
@@ -46,6 +46,13 @@ namespace curl {
          * with user specified flag.
          */
         explicit curl_global(const long);
+
+        /**
+          * Copying disabled to follow RAII idiom.
+          */
+        curl_global(const curl_global&) = delete;
+        curl_global& operator=(const curl_global&) = delete;
+
         /**
          * The virtual destructor will provide an easy and clean
          * way to deallocate resources, closing curl environment
@@ -53,26 +60,6 @@ namespace curl {
          */
         virtual ~curl_global();
     };
-    
-    // Implementation of constructor.
-    curl_global::curl_global() {
-        const CURLcode code = curl_global_init(CURL_GLOBAL_ALL);
-        if (code != CURLE_OK) {
-            throw curl_easy_exception(code,__FUNCTION__);
-        }
-    }
-    
-    // Implementation of overloaded constructor.
-    curl_global::curl_global(const long flag) {
-        const CURLcode code = curl_global_init(flag);
-        if (code != CURLE_OK) {
-            throw curl_easy_exception(code,__FUNCTION__);
-        }
-    }
-    
-    // Implementation of the virtual destructor.
-    curl_global::~curl_global() {
-    }
 }
 
 #endif	/* defined(__curlcpp__curl_global__) */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CURLCPP_SOURCE
   curl_easy.cpp
   curl_header.cpp
+  curl_global.cpp
   curl_form.cpp
   curl_multi.cpp
   curl_share.cpp

--- a/src/curl_global.cpp
+++ b/src/curl_global.cpp
@@ -1,0 +1,24 @@
+#include "curl_global.h"
+
+using curl::curl_global;
+
+curl_global::curl_global()
+{
+    const CURLcode code = curl_global_init(CURL_GLOBAL_ALL);
+    if (code != CURLE_OK) {
+        throw curl_easy_exception(code, __FUNCTION__);
+    }
+}
+
+curl_global::curl_global(const long flag)
+{
+    const CURLcode code = curl_global_init(flag);
+    if (code != CURLE_OK) {
+        throw curl_easy_exception(code, __FUNCTION__);
+    }
+}
+
+curl_global::~curl_global()
+{
+    curl_global_cleanup();
+}


### PR DESCRIPTION
Also moved function definitions to cpp file
Fix for issue "curl_global should call cleanup in destructor" #103