### PR TITLE
Static analyser issues

### DIFF
--- a/src/curl_form.cpp
+++ b/src/curl_form.cpp
@@ -121,7 +121,7 @@ void curl_form::add(const curl_pair<CURLformoption,string> &form_name, const cur
 void curl_form::add(const curl_pair<CURLformoption,string> &form_name, const vector<string> &files) {
     const size_t size = files.size();
     struct curl_forms *new_files;
-    this->is_null(new_files = (struct curl_forms *)calloc(size,sizeof(struct curl_forms)));
+    this->is_null(new_files = new struct curl_forms[size]);
     if (new_files == nullptr) {
         throw bad_alloc();
     }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Errors, found using PVS-Studio:

curlcpp/src/curl_form.cpp   136     err     V611 The memory was allocated using 'malloc/realloc' function but was released using the 'delete' operator. Consider inspecting operation logics behind the 'new_files' variable.
curlcpp/src/curl_form.cpp   139     err     V611 The memory was allocated using 'malloc/realloc' function but was released using the 'delete' operator. Consider inspecting operation logics behind the 'new_files' variable.