### PR TITLE
Update CMake code for installing target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build.log
 .idea/
 cmake-build-debug/
 cmake-build-debug-visual-studio/
+.vscode
+install

--- a/CMake/curlcppConfig.cmake.in
+++ b/CMake/curlcppConfig.cmake.in
@@ -1,5 +1,6 @@
 # curlcppConfig.cmake - Configuration file for external projects.
+@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+find_dependency(CURL CONFIG REQUIRED)
 
-set(CURLCPP_INCLUDE_DIRS "@CURLCPP_SOURCE_DIR@/include")
-set(CURLCPP_LIBRARY_DIRS "@CURLCPP_BINARY_DIR@/src")
-set(CURLCPP_LIBRARIES "@CURLCPP_LIB_LOCATION@")
+include("${CMAKE_CURRENT_LIST_DIR}/curlcppTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ install(EXPORT curlcppTargets
   NAMESPACE curlcpp::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/curlcpp)
 include(CMakePackageConfigHelpers)
-configure_package_config_file(cmake/curlcppConfig.cmake.in
+configure_package_config_file(CMake/curlcppConfig.cmake.in
   "${PROJECT_BINARY_DIR}/curlcppConfig.cmake"
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/curlcpp")
 install(FILES ${PROJECT_BINARY_DIR}/curlcppConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/curlcpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,14 @@
 cmake_minimum_required(VERSION 3.11...3.15)
 
+# Setting up project
+project(curlcpp LANGUAGES CXX)
+
 include(GNUInstallDirs)
+
+set(BUILD_TEST "Build Tests" OFF)
 
 #if using an older VERSION of curl ocsp stapling can be disabled
 set(CURL_MIN_VERSION "7.28.0")
-
-# Setting up project
-project(curlcpp LANGUAGES CXX)
 
 set(DEFAULT_BUILD_TYPE "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -34,11 +36,16 @@ option(CURLCPP_USE_PKGCONFIG
 add_subdirectory(src)
 
 # Set up test directory.
-add_subdirectory(test)
+if(BUILD_TEST)
+	add_subdirectory(test)
+endif()
 
-# Set library location
-set(CURLCPP_LIB_LOCATION "$<TARGET_FILE:${curlcpp}>")
-
-configure_file(CMake/curlcppConfig.cmake.in
-  ${CMAKE_BINARY_DIR}/curlcppConfig.cmake @ONLY)
-install (FILES ${CMAKE_BINARY_DIR}/curlcppConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/curlcpp)
+# Install
+install(EXPORT curlcppTargets
+  NAMESPACE curlcpp::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/curlcpp)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmake/curlcppConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/curlcppConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/curlcpp")
+install(FILES ${PROJECT_BINARY_DIR}/curlcppConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/curlcpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,10 +23,7 @@ set(CURLCPP_HEADER_LIST
   ../include/curl_utility.h
 )
 
-add_library(curlcpp)
-
-target_sources(curlcpp
-PRIVATE
+add_library(curlcpp
   curl_easy.cpp
   curl_header.cpp
   curl_global.cpp
@@ -40,11 +37,14 @@ PRIVATE
   cookie_date.cpp
   cookie_time.cpp
   cookie_datetime.cpp
-PUBLIC
   ${CURLCPP_HEADER_LIST}
 )
 
-target_include_directories(curlcpp PUBLIC ../include)
+add_library(curlcpp::curlcpp ALIAS curlcpp)
+
+target_include_directories(curlcpp PUBLIC
+"$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../include>"
+"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/>")
 
 target_compile_features(curlcpp PUBLIC cxx_std_11)
 
@@ -56,17 +56,17 @@ target_compile_options(curlcpp PRIVATE
 
 if(CURLCPP_USE_PKGCONFIG)
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(libcurl REQUIRED IMPORTED_TARGET libcurl>=${CURL_MIN_VERSION})	
+    pkg_check_modules(libcurl REQUIRED IMPORTED_TARGET libcurl>=${CURL_MIN_VERSION})
     target_link_libraries(curlcpp PUBLIC PkgConfig::libcurl)
 else()
     # Add MacPorts
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         set(CMAKE_PREFIX_PATH /opt/local ${CMAKE_PREFIX_PATH})
     endif()
-	
+
     find_package(CURL ${CURL_MIN_VERSION} REQUIRED)
 
-	target_include_directories(curlcpp PUBLIC ${CURL_INCLUDE_DIRS})
+    target_include_directories(curlcpp PUBLIC ${CURL_INCLUDE_DIRS})
     target_link_libraries(curlcpp PUBLIC ${CURL_LIBRARY})
 endif()
 
@@ -78,5 +78,11 @@ if(IPO_SUPPORTED AND CMAKE_BUILD_TYPE STREQUAL "Release")
     set_target_properties(curlcpp PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
-install (TARGETS curlcpp LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install (FILES ${CURLCPP_HEADER_LIST} DESTINATION include/curlcpp)
+set_target_properties (curlcpp PROPERTIES PUBLIC_HEADER "${CURLCPP_HEADER_LIST}")
+
+include(GNUInstallDirs)
+install(TARGETS curlcpp
+  EXPORT ${PROJECT_NAME}Targets
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
The old "install" target was working poorly in windows.
Now able to include curlcpp using find_package or FetchContent