### PR TITLE
Hotfix/build test option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(curlcpp LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
-set(BUILD_TEST "Build Tests" OFF)
+option(BUILD_TEST "Build Tests" ON)
 
 #if using an older VERSION of curl ocsp stapling can be disabled
 set(CURL_MIN_VERSION "7.28.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(curlcpp LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
-option(BUILD_TEST "Build Tests" ON)
+option(BUILD_TEST "Build Tests" OFF)
 
 #if using an older VERSION of curl ocsp stapling can be disabled
 set(CURL_MIN_VERSION "7.28.0")


### PR DESCRIPTION
Based on the syntax of how `BUILD_TEST` has been defined and its usage, it seems to be that it was meant to be an `option` rather than `set`. Currently the variable `BUILD_TEST` resolves to `Build Tests;OFF`, hence leading to always building the test directory irrespective of the variable.