### PR TITLE
Fix cmake CURL dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
     find_package(CURL ${CURL_MIN_VERSION} REQUIRED)
 
     target_include_directories(curlcpp PUBLIC ${CURL_INCLUDE_DIRS})
-    target_link_libraries(curlcpp PUBLIC ${CURL_LIBRARY})
+    target_link_libraries(curlcpp PUBLIC ${CURL_LIBRARIES})
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
FindCURL from cmake defines the variable `${CURL_LIBRARIES}`, but `${CURL_LIBRARY}` (an empty variable) is used here instead. See [https://cmake.org/cmake/help/v3.23/module/FindCURL.html](https://cmake.org/cmake/help/v3.23/module/FindCURL.html). This has been the case since cmake 3.0, so this fix is backwards compatible.

(The reason why this hasn't been a problem so far is probably due to the fact that CURL libraries are often installed in system directories that are linked to anyway. I noticed this bug when using a custom CURL installation directory.)