### PR TITLE
Fix needed while build with curl 7.83 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,8 +66,12 @@ else()
 
     find_package(CURL ${CURL_MIN_VERSION} REQUIRED)
 
-    target_include_directories(curlcpp PUBLIC ${CURL_INCLUDE_DIRS})
-    target_link_libraries(curlcpp PUBLIC ${CURL_LIBRARIES})
+    if(TARGET CURL::libcurl)
+        target_link_libraries(curlcpp PUBLIC CURL::libcurl)
+    else()
+        target_include_directories(curlcpp PUBLIC ${CURL_INCLUDE_DIRS})
+        target_link_libraries(curlcpp PUBLIC ${CURL_LIBRARIES})
+    endif()
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/src/curl_header.cpp
+++ b/src/curl_header.cpp
@@ -7,56 +7,63 @@
 #include "curl_exception.h"
 #include <algorithm>
 
-using std::string;
-using std::initializer_list;
 using std::for_each;
+using std::initializer_list;
+using std::string;
 
-using curl::curl_header;
-using curl::curl_exception;
+namespace curl
+{
+    // Implementation of constructor.
+    curl_header::curl_header() : size(0), headers(nullptr)
+    {
+        // ... nothing to do here ...
+    }
 
+    // Implementation of the list constructor's initialize method.
+    curl_header::curl_header(initializer_list<string> headers) : size(0), headers(nullptr)
+    {
+        for_each(headers.begin(), headers.end(), [this](const string &header)
+                 { this->add(header); });
+    }
 
-// Implementation of constructor.
-curl_header::curl_header() : size(0), headers(nullptr) {
-    // ... nothing to do here ...
-}
-
-// Implementation of the list constructor's initialize method.
-curl_header::curl_header(initializer_list<string> headers) : size(0), headers(nullptr) {
-    for_each(headers.begin(),headers.end(),[this](const string& header) {
-        this->add(header);
-    });
-}
-
-/**
- * Implementation of assignment operator. The object has just been created, so its members have just
- * been loaded in memory, so we need to give a valid value to them (in this case just to "headers").
- */
-curl_header &curl_header::operator=(const curl_header &header) {
-    if (this == &header) {
+    /**
+     * Implementation of assignment operator. The object has just been created, so its members have just
+     * been loaded in memory, so we need to give a valid value to them (in this case just to "headers").
+     */
+    curl_header &curl_header::operator=(const curl_header &header)
+    {
+        if (this == &header)
+        {
+            return *this;
+        }
+        curl_slist_free_all(this->headers);
+        struct curl_slist *tmp_ptr = header.headers;
+        while (tmp_ptr != nullptr)
+        {
+            this->add(tmp_ptr->data);
+            tmp_ptr = tmp_ptr->next;
+        }
         return *this;
     }
-    curl_slist_free_all(this->headers);
-    struct curl_slist *tmp_ptr = header.headers;
-    while (tmp_ptr != nullptr) {
-        this->add(tmp_ptr->data);
-        tmp_ptr = tmp_ptr->next;
-    }
-    return *this;
-}
 
-// Implementation of destructor.
-curl_header::~curl_header() NOEXCEPT {
-    if (this->headers != nullptr) {
-        curl_slist_free_all(this->headers);
-        this->headers = nullptr;
+    // Implementation of destructor.
+    curl_header::~curl_header() NOEXCEPT
+    {
+        if (this->headers != nullptr)
+        {
+            curl_slist_free_all(this->headers);
+            this->headers = nullptr;
+        }
     }
-}
 
-// Implementation of add overloaded method.
-void curl_header::add(const string& header) {
-    this->headers = curl_slist_append(this->headers,header.c_str());
-    if (this->headers == nullptr) {
-        throw curl_exception("Null pointer exception",__FUNCTION__);
+    // Implementation of add overloaded method.
+    void curl_header::add(const string &header)
+    {
+        this->headers = curl_slist_append(this->headers, header.c_str());
+        if (this->headers == nullptr)
+        {
+            throw curl_exception("Null pointer exception", __FUNCTION__);
+        }
+        ++this->size;
     }
-    ++this->size;
 }

--- a/test/cookie.cpp
+++ b/test/cookie.cpp
@@ -9,7 +9,6 @@
 using std::ostringstream;
 
 using curl::cookie;
-using curl::curl_header;
 using curl::curl_easy;
 using curl::curl_easy_exception;
 using curl::curl_cookie;

--- a/test/custom_request.cpp
+++ b/test/custom_request.cpp
@@ -2,7 +2,6 @@
 #include "curl_form.h"
 #include "curl_header.h"
 
-using curl::curl_header;
 using curl::curl_easy;
 using curl::curl_easy_exception;
 using curl::curlcpp_traceback;
@@ -12,7 +11,7 @@ using curl::curlcpp_traceback;
  */
 int main() {
     // Let's create an object which will contain a list of headers.
-    curl_header header;
+    curl::curl_header header;
     // Easy object to handle the connection.
     curl_easy easy;
 

--- a/test/header.cpp
+++ b/test/header.cpp
@@ -2,7 +2,6 @@
 #include "curl_form.h"
 #include "curl_header.h"
 
-using curl::curl_header;
 using curl::curl_easy;
 using curl::curl_easy_exception;
 using curl::curlcpp_traceback;
@@ -16,7 +15,7 @@ int main() {
     curl_easy easy;
 
 	// Let's create an object which will contain a list of headers.
-	curl_header header;
+	curl::curl_header header;
     header.add("Accept:");
     header.add("Another:yes");
     header.add("Host: example.com");


### PR DESCRIPTION
Fixes: https://github.com/JosephP91/curlcpp/issues/143
After curl 7.83 curl exports `header.h` and its symbol, which have a struct curl_header. https://github.com/curl/curl/blob/0842936292f9bc614f8335b25a3b4b6b25dae5a8/include/curl/header.h#L25 
Which is now creating conflict with https://github.com/JosephP91/curlcpp/blob/55bc50c244ecb5a14ac21b3b2e2931267a5bb802/include/curl_header.h#L41

To fix this, I have changed the `curl::curl_header` member function in the curl namespace, and now using curl_header with the curl namespace.