### PR TITLE
Add getter for underlying handle in curl_share

### DIFF
--- a/include/curl_share.h
+++ b/include/curl_share.h
@@ -127,6 +127,10 @@ namespace curl {
          * structure.
          */
         template<typename Iterator> void add(Iterator, Iterator);
+        /**
+         * Simple getter method used to return the underlying shared handle.
+         */
+        CURLSH *get() const;
     protected:
     	void initialize_curl_share();
     private:
@@ -157,6 +161,11 @@ namespace curl {
         for (; begin != end; ++begin) {
             this->add(*begin);
         }
+    }
+
+    // Implementation of underlying share getter method.
+    inline CURLSH *curl_share::get() const {
+        return this->curl;
     }
 }
 


### PR DESCRIPTION
Currently, you cannot use the curl_share class because there's no way to pass the underlying handle to curl_easy::add<CURLOPT_SHARE>. This commit resolves it.