### PR TITLE
fix: remove use of `CURLOPT_CLOSEPOLICY` (removed since curl 8.10+)

### DIFF
--- a/include/curl_easy.h
+++ b/include/curl_easy.h
@@ -356,13 +356,6 @@ namespace curl  {
         /* Max amount of cached alive connections */
         CURLCPP_DEFINE_OPTION(CURLOPT_MAXCONNECTS, long);
 
-        /* Renamed / obsoleted since 7.37 */
-#if defined(LIBCURL_VERSION_NUM) && LIBCURL_VERSION_NUM > 0x072500
-        CURLCPP_DEFINE_OPTION(CURLOPT_OBSOLETE72, long); /* OBSOLETE, do not use! */
-#else
-        CURLCPP_DEFINE_OPTION(CURLOPT_CLOSEPOLICY, long);
-#endif
-
         /* 73 = OBSOLETE */
 
         /* Set to explicitly use a new connection for the upcoming transfer.


### PR DESCRIPTION
fixes #155
fixes #158

https://github.com/Homebrew/homebrew-core/pull/206666