### PR TITLE
fix: get_message_queued returning active_transfers

### DIFF
--- a/include/curl_multi.h
+++ b/include/curl_multi.h
@@ -362,7 +362,7 @@ namespace curl {
 
     // Implementation of get_message_queued method.
     inline int curl_multi::get_message_queued() const NOEXCEPT {
-        return this->active_transfers;
+        return this->message_queued;
     }
 
     // Implementation of curl_message get_message method.


### PR DESCRIPTION
Hi,
curl_multi::get_message_queued() was returning active_transfers, behaving like curl_multi::get_active_transfers().
Regards 